### PR TITLE
frontend: monochrome black & white theme

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -4,7 +4,7 @@ import Footer from '../pages/components/Footer';
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-br from-gray-50 to-blue-50 dark:from-gray-900 dark:to-blue-900">
+    <div className="min-h-screen flex flex-col bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black">
       <Header />
       <main className="flex-grow transition-colors">{children}</main>
       <Footer />

--- a/frontend/components/animations/OpenNotifAnimation.tsx
+++ b/frontend/components/animations/OpenNotifAnimation.tsx
@@ -24,13 +24,13 @@ const OpenNotifAnimation: React.FC<OpenNotifAnimationProps> = ({
         {/* Define gradients and filters for better visuals */}
         <defs>
           <linearGradient id="awsGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor="#FF9900" />
-            <stop offset="100%" stopColor="#ED8600" />
+            <stop offset="0%" stopColor="#374151" />
+            <stop offset="100%" stopColor="#1f2937" />
           </linearGradient>
-          
+
           <linearGradient id="userGradient" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stopColor="#4CAF50" />
-            <stop offset="100%" stopColor="#3D8B40" />
+            <stop offset="0%" stopColor="#6b7280" />
+            <stop offset="100%" stopColor="#4b5563" />
           </linearGradient>
           
           <filter id="shadowEffect" x="-20%" y="-20%" width="140%" height="140%">
@@ -53,122 +53,122 @@ const OpenNotifAnimation: React.FC<OpenNotifAnimationProps> = ({
         
         {/* Title with animation */}
         <g filter="url(#shadowEffect)">
-          <text x="450" y="50" fontFamily="Arial, sans-serif" fontSize="36" fontWeight="bold" textAnchor="middle" fill="#232F3E">
+          <text x="450" y="50" fontFamily="Arial, sans-serif" fontSize="36" fontWeight="bold" textAnchor="middle" fill="#111827">
             Open-Notif: CLI for User-Company Connectivity
             <animate attributeName="opacity" values="0.9;1;0.9" dur="3s" repeatCount="indefinite" />
           </text>
         </g>
         
         {/* AWS Chalice - Increased size */}
-        <rect id="chalice" x="100" y="90" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#232F3E" strokeWidth="2" filter="url(#shadowEffect)">
+        <rect id="chalice" x="100" y="90" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#111827" strokeWidth="2" filter="url(#shadowEffect)">
           <animate attributeName="opacity" values="0.8;1;0.8" dur="2s" repeatCount="indefinite" />
         </rect>
-        <text x="175" y="140" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#232F3E">
+        <text x="175" y="140" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#ffffff">
           AWS Chalice
         </text>
         
         {/* AWS SNS - Increased size */}
-        <rect id="sns" x="375" y="90" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#232F3E" strokeWidth="2" filter="url(#shadowEffect)">
+        <rect id="sns" x="375" y="90" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#111827" strokeWidth="2" filter="url(#shadowEffect)">
           <animate attributeName="opacity" values="0.8;1;0.8" dur="2s" repeatCount="indefinite" begin="0.5s" />
         </rect>
-        <text x="450" y="140" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#232F3E">
+        <text x="450" y="140" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#ffffff">
           AWS SNS
         </text>
         
         {/* SQS 1 - Increased size */}
-        <rect id="sqs1" x="225" y="210" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#232F3E" strokeWidth="2" filter="url(#shadowEffect)">
+        <rect id="sqs1" x="225" y="210" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#111827" strokeWidth="2" filter="url(#shadowEffect)">
           <animate attributeName="opacity" values="0.8;1;0.8" dur="2s" repeatCount="indefinite" begin="1s" />
         </rect>
-        <text x="300" y="260" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#232F3E">
+        <text x="300" y="260" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#ffffff">
           AWS SQS
         </text>
         
         {/* SQS 2 - Increased size */}
-        <rect id="sqs2" x="525" y="210" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#232F3E" strokeWidth="2" filter="url(#shadowEffect)">
+        <rect id="sqs2" x="525" y="210" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#111827" strokeWidth="2" filter="url(#shadowEffect)">
           <animate attributeName="opacity" values="0.8;1;0.8" dur="2s" repeatCount="indefinite" begin="1s" />
         </rect>
-        <text x="600" y="260" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#232F3E">
+        <text x="600" y="260" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#ffffff">
           AWS SQS
         </text>
         
         {/* Lambda 1 - Increased size */}
-        <rect id="lambda1" x="225" y="330" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#232F3E" strokeWidth="2" filter="url(#shadowEffect)">
+        <rect id="lambda1" x="225" y="330" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#111827" strokeWidth="2" filter="url(#shadowEffect)">
           <animate attributeName="opacity" values="0.8;1;0.8" dur="2s" repeatCount="indefinite" begin="1.5s" />
         </rect>
-        <text x="300" y="380" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#232F3E">
+        <text x="300" y="380" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#ffffff">
           AWS Lambda
         </text>
         
         {/* Lambda 2 - Increased size */}
-        <rect id="lambda2" x="525" y="330" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#232F3E" strokeWidth="2" filter="url(#shadowEffect)">
+        <rect id="lambda2" x="525" y="330" width="150" height="90" rx="15" fill="url(#awsGradient)" stroke="#111827" strokeWidth="2" filter="url(#shadowEffect)">
           <animate attributeName="opacity" values="0.8;1;0.8" dur="2s" repeatCount="indefinite" begin="1.5s" />
         </rect>
-        <text x="600" y="380" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#232F3E">
+        <text x="600" y="380" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#ffffff">
           AWS Lambda
         </text>
         
         {/* User Call - Moved to left edge */}
-        <rect id="usercall" x="50" y="430" width="170" height="60" rx="25" fill="url(#userGradient)" stroke="#232F3E" strokeWidth="2" filter="url(#shadowEffect)">
+        <rect id="usercall" x="50" y="430" width="170" height="60" rx="25" fill="url(#userGradient)" stroke="#111827" strokeWidth="2" filter="url(#shadowEffect)">
           <animate attributeName="opacity" values="0.8;1;0.8" dur="2s" repeatCount="indefinite" begin="2s" />
         </rect>
-        <text x="135" y="468" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#232F3E">
+        <text x="135" y="468" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#ffffff">
           User Call
         </text>
         
         {/* User Email - Moved to right edge */}
-        <rect id="useremail" x="680" y="430" width="170" height="60" rx="25" fill="url(#userGradient)" stroke="#232F3E" strokeWidth="2" filter="url(#shadowEffect)">
+        <rect id="useremail" x="680" y="430" width="170" height="60" rx="25" fill="url(#userGradient)" stroke="#111827" strokeWidth="2" filter="url(#shadowEffect)">
           <animate attributeName="opacity" values="0.8;1;0.8" dur="2s" repeatCount="indefinite" begin="2s" />
         </rect>
-        <text x="765" y="468" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#232F3E">
+        <text x="765" y="468" fontFamily="Arial, sans-serif" fontSize="20" fontWeight="bold" textAnchor="middle" fill="#ffffff">
           User Email
         </text>
         
         {/* Enhanced connection paths with better visibility - Updated coordinates */}
         {/* Chalice to SNS */}
-        <path id="path1-1" d="M240,135 L390,135" stroke="#232F3E" strokeWidth="3" fill="none">
+        <path id="path1-1" d="M240,135 L390,135" stroke="#6b7280" strokeWidth="3" fill="none">
           <animate attributeName="stroke-dasharray" values="1,15;15,1;1,15" dur="2s" repeatCount="indefinite" />
         </path>
-        <polygon points="390,135 380,130 380,140" fill="#232F3E" />
+        <polygon points="390,135 380,130 380,140" fill="#6b7280" />
         
         {/* SNS to SQS 1 */}
-        <path id="path2-1" d="M450,170 Q450,195 325,220" stroke="#232F3E" strokeWidth="3" fill="none">
+        <path id="path2-1" d="M450,170 Q450,195 325,220" stroke="#6b7280" strokeWidth="3" fill="none">
           <animate attributeName="stroke-dasharray" values="1,15;15,1;1,15" dur="2s" repeatCount="indefinite" />
         </path>
-        <polygon points="325,220 335,215 335,225" fill="#232F3E" />
+        <polygon points="325,220 335,215 335,225" fill="#6b7280" />
         
         {/* SNS to SQS 2 */}
-        <path id="path2-2" d="M450,170 Q450,195 575,220" stroke="#232F3E" strokeWidth="3" fill="none">
+        <path id="path2-2" d="M450,170 Q450,195 575,220" stroke="#6b7280" strokeWidth="3" fill="none">
           <animate attributeName="stroke-dasharray" values="1,15;15,1;1,15" dur="2s" repeatCount="indefinite" />
         </path>
-        <polygon points="575,220 565,215 565,225" fill="#232F3E" />
+        <polygon points="575,220 565,215 565,225" fill="#6b7280" />
         
         {/* SQS 1 to Lambda 1 */}
-        <path id="path3-1" d="M300,290 L300,330" stroke="#232F3E" strokeWidth="3" fill="none">
+        <path id="path3-1" d="M300,290 L300,330" stroke="#6b7280" strokeWidth="3" fill="none">
           <animate attributeName="stroke-dasharray" values="1,15;15,1;1,15" dur="2s" repeatCount="indefinite" />
         </path>
-        <polygon points="300,340 295,330 305,330" fill="#232F3E" />
+        <polygon points="300,340 295,330 305,330" fill="#6b7280" />
         
         {/* SQS 2 to Lambda 2 */}
-        <path id="path3-2" d="M600,290 L600,330" stroke="#232F3E" strokeWidth="3" fill="none">
+        <path id="path3-2" d="M600,290 L600,330" stroke="#6b7280" strokeWidth="3" fill="none">
           <animate attributeName="stroke-dasharray" values="1,15;15,1;1,15" dur="2s" repeatCount="indefinite" />
         </path>
-        <polygon points="600,340 595,330 605,330" fill="#232F3E" />
+        <polygon points="600,340 595,330 605,330" fill="#6b7280" />
         
         {/* Lambda 1 to User Call - Updated path */}
-        <path id="path4-1" d="M300,410 Q300,425 135,440" stroke="#232F3E" strokeWidth="3" fill="none">
+        <path id="path4-1" d="M300,410 Q300,425 135,440" stroke="#6b7280" strokeWidth="3" fill="none">
           <animate attributeName="stroke-dasharray" values="1,15;15,1;1,15" dur="2s" repeatCount="indefinite" />
         </path>
-        <polygon points="135,440 145,435 145,445" fill="#232F3E" />
+        <polygon points="135,440 145,435 145,445" fill="#6b7280" />
         
         {/* Lambda 2 to User Email - Updated path */}
-        <path id="path4-2" d="M600,410 Q600,425 765,440" stroke="#232F3E" strokeWidth="3" fill="none">
+        <path id="path4-2" d="M600,410 Q600,425 765,440" stroke="#6b7280" strokeWidth="3" fill="none">
           <animate attributeName="stroke-dasharray" values="1,15;15,1;1,15" dur="2s" repeatCount="indefinite" />
         </path>
-        <polygon points="765,440 755,435 755,445" fill="#232F3E" />
+        <polygon points="765,440 755,435 755,445" fill="#6b7280" />
         
         {/* Enhanced moving circles along paths - Updated paths */}
         {/* Path 1 - AWS Chalice to SNS */}
-        <circle cx="0" cy="0" r="8" fill="#FF5722" filter="url(#glowEffect)">
+        <circle cx="0" cy="0" r="8" fill="#111827" filter="url(#glowEffect)">
           <animateMotion dur="2s" repeatCount="indefinite" rotate="auto" begin="0s">
             <mpath href="#path1-1" />
           </animateMotion>
@@ -176,7 +176,7 @@ const OpenNotifAnimation: React.FC<OpenNotifAnimationProps> = ({
         </circle>
         
         {/* Path 2-1 - SNS to SQS 1 */}
-        <circle cx="0" cy="0" r="8" fill="#FF5722" filter="url(#glowEffect)">
+        <circle cx="0" cy="0" r="8" fill="#111827" filter="url(#glowEffect)">
           <animateMotion dur="2s" repeatCount="indefinite" rotate="auto" begin="2s">
             <mpath href="#path2-1" />
           </animateMotion>
@@ -184,7 +184,7 @@ const OpenNotifAnimation: React.FC<OpenNotifAnimationProps> = ({
         </circle>
         
         {/* Path 2-2 - SNS to SQS 2 */}
-        <circle cx="0" cy="0" r="8" fill="#FF5722" filter="url(#glowEffect)">
+        <circle cx="0" cy="0" r="8" fill="#111827" filter="url(#glowEffect)">
           <animateMotion dur="2s" repeatCount="indefinite" rotate="auto" begin="2.5s">
             <mpath href="#path2-2" />
           </animateMotion>
@@ -192,7 +192,7 @@ const OpenNotifAnimation: React.FC<OpenNotifAnimationProps> = ({
         </circle>
         
         {/* Path 3-1 - SQS 1 to Lambda 1 */}
-        <circle cx="0" cy="0" r="8" fill="#FF5722" filter="url(#glowEffect)">
+        <circle cx="0" cy="0" r="8" fill="#111827" filter="url(#glowEffect)">
           <animateMotion dur="1.5s" repeatCount="indefinite" rotate="auto" begin="4s">
             <mpath href="#path3-1" />
           </animateMotion>
@@ -200,7 +200,7 @@ const OpenNotifAnimation: React.FC<OpenNotifAnimationProps> = ({
         </circle>
         
         {/* Path 3-2 - SQS 2 to Lambda 2 */}
-        <circle cx="0" cy="0" r="8" fill="#FF5722" filter="url(#glowEffect)">
+        <circle cx="0" cy="0" r="8" fill="#111827" filter="url(#glowEffect)">
           <animateMotion dur="1.5s" repeatCount="indefinite" rotate="auto" begin="4.5s">
             <mpath href="#path3-2" />
           </animateMotion>
@@ -208,7 +208,7 @@ const OpenNotifAnimation: React.FC<OpenNotifAnimationProps> = ({
         </circle>
         
         {/* Path 4-1 - Lambda 1 to User Call */}
-        <circle cx="0" cy="0" r="8" fill="#FF5722" filter="url(#glowEffect)">
+        <circle cx="0" cy="0" r="8" fill="#111827" filter="url(#glowEffect)">
           <animateMotion dur="1.5s" repeatCount="indefinite" rotate="auto" begin="5.5s">
             <mpath href="#path4-1" />
           </animateMotion>
@@ -216,7 +216,7 @@ const OpenNotifAnimation: React.FC<OpenNotifAnimationProps> = ({
         </circle>
         
         {/* Path 4-2 - Lambda 2 to User Email */}
-        <circle cx="0" cy="0" r="8" fill="#FF5722" filter="url(#glowEffect)">
+        <circle cx="0" cy="0" r="8" fill="#111827" filter="url(#glowEffect)">
           <animateMotion dur="1.5s" repeatCount="indefinite" rotate="auto" begin="6s">
             <mpath href="#path4-2" />
           </animateMotion>
@@ -226,7 +226,7 @@ const OpenNotifAnimation: React.FC<OpenNotifAnimationProps> = ({
         {/* Continuous flow animation showing complete path - Updated coordinates */}
         <g>
           {/* Path 1 - Complete flow through left side - Updated end point */}
-          <circle cx="0" cy="0" r="6" fill="#4CAF50" filter="url(#glowEffect)">
+          <circle cx="0" cy="0" r="6" fill="#4b5563" filter="url(#glowEffect)">
             <animate attributeName="opacity" values="1;0.7;1" dur="1s" repeatCount="indefinite" />
             <animateMotion 
               path="M180,135 L390,135 L450,135 Q450,195 325,220 L300,220 L300,330 Q300,425 135,440" 
@@ -240,7 +240,7 @@ const OpenNotifAnimation: React.FC<OpenNotifAnimationProps> = ({
           </circle>
           
           {/* Path 2 - Complete flow through right side - Updated end point */}
-          <circle cx="0" cy="0" r="6" fill="#4CAF50" filter="url(#glowEffect)">
+          <circle cx="0" cy="0" r="6" fill="#4b5563" filter="url(#glowEffect)">
             <animate attributeName="opacity" values="1;0.7;1" dur="1s" repeatCount="indefinite" begin="4s" />
             <animateMotion 
               path="M450,135 Q450,195 575,220 L600,220 L600,330 Q600,425 765,440" 
@@ -258,42 +258,42 @@ const OpenNotifAnimation: React.FC<OpenNotifAnimationProps> = ({
         {/* Additional visual enhancements - Updated for larger box sizes and positions */}
         <g>
           {/* Pulsing highlight on the active component */}
-          <rect id="highlight-chalice" x="98" y="88" width="154" height="94" rx="17" fill="none" stroke="#FF5722" strokeWidth="2">
+          <rect id="highlight-chalice" x="98" y="88" width="154" height="94" rx="17" fill="none" stroke="#111827" strokeWidth="2">
             <animate attributeName="opacity" values="0;1;0" dur="8s" repeatCount="indefinite" begin="0s" />
             <animate attributeName="stroke-width" values="2;4;2" dur="8s" repeatCount="indefinite" begin="0s" />
           </rect>
           
-          <rect id="highlight-sns" x="373" y="88" width="154" height="94" rx="17" fill="none" stroke="#FF5722" strokeWidth="2">
+          <rect id="highlight-sns" x="373" y="88" width="154" height="94" rx="17" fill="none" stroke="#111827" strokeWidth="2">
             <animate attributeName="opacity" values="0;1;0" dur="8s" repeatCount="indefinite" begin="1s" />
             <animate attributeName="stroke-width" values="2;4;2" dur="8s" repeatCount="indefinite" begin="1s" />
           </rect>
           
-          <rect id="highlight-sqs1" x="223" y="208" width="154" height="94" rx="17" fill="none" stroke="#FF5722" strokeWidth="2">
+          <rect id="highlight-sqs1" x="223" y="208" width="154" height="94" rx="17" fill="none" stroke="#111827" strokeWidth="2">
             <animate attributeName="opacity" values="0;1;0" dur="8s" repeatCount="indefinite" begin="2s" />
             <animate attributeName="stroke-width" values="2;4;2" dur="8s" repeatCount="indefinite" begin="2s" />
           </rect>
           
-          <rect id="highlight-sqs2" x="523" y="208" width="154" height="94" rx="17" fill="none" stroke="#FF5722" strokeWidth="2">
+          <rect id="highlight-sqs2" x="523" y="208" width="154" height="94" rx="17" fill="none" stroke="#111827" strokeWidth="2">
             <animate attributeName="opacity" values="0;1;0" dur="8s" repeatCount="indefinite" begin="2.5s" />
             <animate attributeName="stroke-width" values="2;4;2" dur="8s" repeatCount="indefinite" begin="2.5s" />
           </rect>
           
-          <rect id="highlight-lambda1" x="223" y="328" width="154" height="94" rx="17" fill="none" stroke="#FF5722" strokeWidth="2">
+          <rect id="highlight-lambda1" x="223" y="328" width="154" height="94" rx="17" fill="none" stroke="#111827" strokeWidth="2">
             <animate attributeName="opacity" values="0;1;0" dur="8s" repeatCount="indefinite" begin="3s" />
             <animate attributeName="stroke-width" values="2;4;2" dur="8s" repeatCount="indefinite" begin="3s" />
           </rect>
           
-          <rect id="highlight-lambda2" x="523" y="328" width="154" height="94" rx="17" fill="none" stroke="#FF5722" strokeWidth="2">
+          <rect id="highlight-lambda2" x="523" y="328" width="154" height="94" rx="17" fill="none" stroke="#111827" strokeWidth="2">
             <animate attributeName="opacity" values="0;1;0" dur="8s" repeatCount="indefinite" begin="3.5s" />
             <animate attributeName="stroke-width" values="2;4;2" dur="8s" repeatCount="indefinite" begin="3.5s" />
           </rect>
           
-          <rect id="highlight-usercall" x="48" y="428" width="174" height="64" rx="27" fill="none" stroke="#FF5722" strokeWidth="2">
+          <rect id="highlight-usercall" x="48" y="428" width="174" height="64" rx="27" fill="none" stroke="#111827" strokeWidth="2">
             <animate attributeName="opacity" values="0;1;0" dur="8s" repeatCount="indefinite" begin="4s" />
             <animate attributeName="stroke-width" values="2;4;2" dur="8s" repeatCount="indefinite" begin="4s" />
           </rect>
           
-          <rect id="highlight-useremail" x="678" y="428" width="174" height="64" rx="27" fill="none" stroke="#FF5722" strokeWidth="2">
+          <rect id="highlight-useremail" x="678" y="428" width="174" height="64" rx="27" fill="none" stroke="#111827" strokeWidth="2">
             <animate attributeName="opacity" values="0;1;0" dur="8s" repeatCount="indefinite" begin="4.5s" />
             <animate attributeName="stroke-width" values="2;4;2" dur="8s" repeatCount="indefinite" begin="4.5s" />
           </rect>

--- a/frontend/components/primitives/GradientHeading.tsx
+++ b/frontend/components/primitives/GradientHeading.tsx
@@ -17,8 +17,9 @@ const sizeClasses = {
 } as const;
 
 /**
- * Title with the signature purple → pink → blue gradient that appears on every section.
- * Animated in from a slight upward offset when scrolled into view.
+ * Title with the signature monochrome gradient (near-black → mid-gray in light mode,
+ * white → mid-gray in dark) that appears on every section. Animated in from a slight
+ * upward offset when scrolled into view.
  */
 export default function GradientHeading({
   children,
@@ -36,7 +37,7 @@ export default function GradientHeading({
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: 0.5, delay: 0.1 }}
-      className={`${sizeClasses[size]} ${alignment} font-bold bg-gradient-to-r from-purple-600 via-pink-600 to-blue-600 bg-clip-text text-transparent ${className}`}
+      className={`${sizeClasses[size]} ${alignment} font-bold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-white dark:to-gray-400 bg-clip-text text-transparent ${className}`}
     >
       {children}
     </Component>

--- a/frontend/components/primitives/InpersonaNavLink.tsx
+++ b/frontend/components/primitives/InpersonaNavLink.tsx
@@ -1,13 +1,15 @@
 import { motion } from 'framer-motion';
 import { type MouseEventHandler } from 'react';
 
+// Grayscale shimmer: mid/light grays cycle through so the animated halo reads on
+// both light and dark backgrounds (a dark-gray halo would vanish in dark mode).
 const gradientStops = [
-  'linear-gradient(to right, #9333EA, #EC4899, #3B82F6)',
-  'linear-gradient(to right, #22C55E, #EAB308, #EC4899)',
-  'linear-gradient(to right, #3B82F6, #F43F5E, #8B5CF6)',
-  'linear-gradient(to right, #EAB308, #8B5CF6, #22C55E)',
-  'linear-gradient(to right, #F43F5E, #22C55E, #3B82F6)',
-  'linear-gradient(to right, #9333EA, #EC4899, #3B82F6)',
+  'linear-gradient(to right, #4b5563, #d1d5db, #4b5563)',
+  'linear-gradient(to right, #9ca3af, #f3f4f6, #9ca3af)',
+  'linear-gradient(to right, #6b7280, #e5e7eb, #374151)',
+  'linear-gradient(to right, #374151, #d1d5db, #6b7280)',
+  'linear-gradient(to right, #9ca3af, #4b5563, #9ca3af)',
+  'linear-gradient(to right, #4b5563, #d1d5db, #4b5563)',
 ];
 
 const animationConfig = {
@@ -28,7 +30,7 @@ interface InpersonaNavLinkProps {
 }
 
 /**
- * The animated, color-cycling "Inpersona" link used in both the desktop and
+ * The animated, grayscale-shimmering "Inpersona" link used in both the desktop and
  * mobile navs. Renders three stacked gradient layers (blur halo, soft glow,
  * crisp border) with a solid pill on top so the underlying text stays legible.
  */
@@ -43,7 +45,7 @@ export default function InpersonaNavLink({
       href={href}
       onClick={onClick}
       whileHover={{ scale: 1.05 }}
-      className={`relative whitespace-nowrap font-medium px-3 py-1 rounded-full text-purple-600 dark:text-purple-400 max-w-[140px] ${
+      className={`relative whitespace-nowrap font-medium px-3 py-1 rounded-full text-gray-900 dark:text-gray-100 max-w-[140px] ${
         variant === 'mobile' ? 'inline-block' : ''
       }`}
     >

--- a/frontend/pages/components/Achievements.tsx
+++ b/frontend/pages/components/Achievements.tsx
@@ -6,14 +6,17 @@ import GradientHeading from '../../components/primitives/GradientHeading';
 import config from '../../types/config';
 import { asIcon, type Icon } from '../../types/icons';
 
+// All company marks render in a single grayscale tone to keep the section monochrome;
+// the icon shapes themselves stay recognizable.
+const ICON_TONE = 'text-gray-700 dark:text-gray-300';
 const companyIcons: Record<string, { Icon: Icon; className: string }> = {
-  dell: { Icon: asIcon(SiDell), className: 'text-blue-700 dark:text-blue-400' },
-  nvidia: { Icon: asIcon(SiNvidia), className: 'text-green-600 dark:text-green-400' },
-  amazon: { Icon: asIcon(SiAmazon), className: 'text-orange-500 dark:text-orange-400' },
+  dell: { Icon: asIcon(SiDell), className: ICON_TONE },
+  nvidia: { Icon: asIcon(SiNvidia), className: ICON_TONE },
+  amazon: { Icon: asIcon(SiAmazon), className: ICON_TONE },
   // Kelley School of Business — there's no university brand icon in react-icons,
-  // so we use a graduation cap in IU crimson as a recognizable stand-in.
-  kelley: { Icon: asIcon(FaGraduationCap), className: 'text-red-700 dark:text-red-400' },
-  ycombinator: { Icon: asIcon(SiYcombinator), className: 'text-orange-500 dark:text-orange-400' },
+  // so we use a graduation cap as a recognizable stand-in.
+  kelley: { Icon: asIcon(FaGraduationCap), className: ICON_TONE },
+  ycombinator: { Icon: asIcon(SiYcombinator), className: ICON_TONE },
 };
 
 export default function Achievements() {
@@ -37,7 +40,7 @@ export default function Achievements() {
                 transition={{ delay: index * 0.08 }}
                 className="group relative flex h-full flex-col bg-white dark:bg-gray-700 rounded-xl shadow-md hover:shadow-xl transition-shadow p-6 overflow-hidden"
               >
-                <div className="pointer-events-none absolute top-0 right-0 w-20 h-20 bg-gradient-to-br from-purple-400/20 to-blue-500/20 rounded-bl-full translate-x-5 -translate-y-5" />
+                <div className="pointer-events-none absolute top-0 right-0 w-20 h-20 bg-gradient-to-br from-gray-400/20 to-gray-600/20 dark:from-white/10 dark:to-white/5 rounded-bl-full translate-x-5 -translate-y-5" />
 
                 <div className="flex items-start mb-4">
                   {iconConfig && (
@@ -46,7 +49,7 @@ export default function Achievements() {
                     </div>
                   )}
                   <div>
-                    <h3 className="font-bold text-lg text-gray-800 dark:text-white group-hover:text-purple-600 dark:group-hover:text-purple-400 transition-colors">
+                    <h3 className="font-bold text-lg text-gray-800 dark:text-white group-hover:text-gray-900 dark:group-hover:text-gray-300 transition-colors">
                       {item.title}
                     </h3>
                     <p className="text-sm text-gray-500 dark:text-gray-300">{item.date}</p>
@@ -63,7 +66,7 @@ export default function Achievements() {
                       href={item.link}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center text-sm font-medium text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300"
+                      className="inline-flex items-center text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-gray-600 dark:hover:text-gray-300"
                     >
                       Learn more
                       <svg

--- a/frontend/pages/components/ContactForm.tsx
+++ b/frontend/pages/components/ContactForm.tsx
@@ -13,13 +13,13 @@ export default function ContactForm() {
   return (
     <div className="w-full max-w-2xl mx-auto p-6">
       {state.succeeded ? (
-        <div className="text-center p-8 bg-gradient-to-r from-rose-400/10 via-fuchsia-500/10 to-indigo-500/10 rounded-2xl border border-gray-200 dark:border-gray-700 animate-scale-in">
+        <div className="text-center p-8 bg-gradient-to-r from-gray-100 to-gray-200 dark:from-gray-800 dark:to-gray-700 rounded-2xl border border-gray-200 dark:border-gray-700 animate-scale-in">
           <div className="mb-4">
-            <svg className="w-16 h-16 mx-auto text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <svg className="w-16 h-16 mx-auto text-gray-900 dark:text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
             </svg>
           </div>
-          <h3 className="text-2xl font-bold bg-gradient-to-r from-rose-400 via-fuchsia-500 to-indigo-500 bg-clip-text text-transparent mb-2">
+          <h3 className="text-2xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-white dark:to-gray-400 bg-clip-text text-transparent mb-2">
             Message Sent Successfully!
           </h3>
           <p className="text-gray-600 dark:text-gray-300">
@@ -44,7 +44,7 @@ export default function ContactForm() {
               </label>
               <input
                 className="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-white/50 dark:bg-gray-700/50 
-                         focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all duration-300
+                         focus:ring-2 focus:ring-gray-900 dark:focus:ring-gray-300 focus:border-transparent transition-all duration-300
                          text-gray-800 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-500"
                 id="name"
                 type="text"
@@ -61,7 +61,7 @@ export default function ContactForm() {
               </label>
               <input
                 className="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-white/50 dark:bg-gray-700/50 
-                         focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all duration-300
+                         focus:ring-2 focus:ring-gray-900 dark:focus:ring-gray-300 focus:border-transparent transition-all duration-300
                          text-gray-800 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-500"
                 id="email"
                 type="email"
@@ -78,7 +78,7 @@ export default function ContactForm() {
               </label>
               <textarea
                 className="w-full px-4 py-3 rounded-lg border border-gray-200 dark:border-gray-600 bg-white/50 dark:bg-gray-700/50 
-                         focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all duration-300
+                         focus:ring-2 focus:ring-gray-900 dark:focus:ring-gray-300 focus:border-transparent transition-all duration-300
                          text-gray-800 dark:text-gray-200 placeholder-gray-400 dark:placeholder-gray-500 min-h-[150px] resize-y"
                 id="message"
                 name="message"
@@ -93,15 +93,15 @@ export default function ContactForm() {
               <button 
                 type="submit"
                 disabled={state.submitting}
-                className="w-full sm:w-auto px-8 py-3 bg-gradient-to-r from-rose-400 via-fuchsia-500 to-indigo-500 
-                         text-white font-medium rounded-lg shadow-lg hover:shadow-xl 
+                className="w-full sm:w-auto px-8 py-3 bg-gray-900 text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200
+                         font-medium rounded-lg shadow-lg hover:shadow-xl
                          transition-all duration-300 hover:scale-[1.02] active:scale-[0.98]
                          disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <span className="relative inline-flex items-center">
                   {state.submitting ? (
                     <>
-                      <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                      <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white dark:text-gray-900" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                         <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
                         <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
                       </svg>

--- a/frontend/pages/components/Experience.tsx
+++ b/frontend/pages/components/Experience.tsx
@@ -27,7 +27,7 @@ export default function Experience() {
                   exp.iconOnly ? 'bg-white' : ''
                 }`}
               >
-                <div className="absolute inset-0 z-10 bg-gradient-to-r from-purple-600/50 to-blue-600/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                <div className="absolute inset-0 z-10 bg-gradient-to-r from-black/40 to-black/10 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                 <img
                   src={exp.image}
                   alt={`${exp.company} logo`}
@@ -51,7 +51,7 @@ export default function Experience() {
                     href={exp.companyUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-2 mt-3 text-sm text-purple-600 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300 transition-colors"
+                    className="inline-flex items-center gap-2 mt-3 text-sm text-gray-900 dark:text-gray-100 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
                   >
                     <ExternalLink size={14} />
                     <span>Visit Company Page</span>
@@ -59,7 +59,7 @@ export default function Experience() {
                 )}
               </div>
 
-              <div className="pointer-events-none absolute top-0 right-0 w-16 h-16 bg-gradient-to-br from-purple-600/20 to-blue-600/20 dark:from-purple-600/10 dark:to-blue-600/10 rotate-45 translate-x-8 -translate-y-8" />
+              <div className="pointer-events-none absolute top-0 right-0 w-16 h-16 bg-gradient-to-br from-gray-900/15 to-gray-500/10 dark:from-white/10 dark:to-white/5 rotate-45 translate-x-8 -translate-y-8" />
             </motion.article>
           ))}
         </div>

--- a/frontend/pages/components/Footer.tsx
+++ b/frontend/pages/components/Footer.tsx
@@ -22,7 +22,7 @@ export default function Footer() {
               target="_blank"
               rel="noreferrer"
               aria-label={label}
-              className="text-gray-600 hover:text-purple-600 dark:text-gray-400 dark:hover:text-purple-400 transition-colors duration-200"
+              className="text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors duration-200"
             >
               <Icon className="w-6 h-6" />
             </a>

--- a/frontend/pages/components/Header.tsx
+++ b/frontend/pages/components/Header.tsx
@@ -81,7 +81,7 @@ export default function Header() {
                     href={item.url}
                     download={item.isDownload}
                     onClick={handleNavClick(item, true)}
-                    className="text-gray-700 dark:text-gray-200 hover:text-purple-600 dark:hover:text-purple-400 transition-colors"
+                    className="text-gray-700 dark:text-gray-200 hover:text-black dark:hover:text-white transition-colors"
                   >
                     {item.title}
                   </a>
@@ -108,11 +108,11 @@ function NavLink({
         href={item.url}
         download={item.isDownload}
         onClick={onClick}
-        className="whitespace-nowrap font-medium text-gray-700 dark:text-gray-200 hover:text-purple-600 dark:hover:text-purple-400 transition-colors"
+        className="whitespace-nowrap font-medium text-gray-700 dark:text-gray-200 hover:text-black dark:hover:text-white transition-colors"
       >
         {item.title}
       </a>
-      <div className="absolute bottom-0 left-0 w-full h-0.5 bg-gradient-to-r from-purple-600 via-pink-600 to-blue-600 scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
+      <div className="absolute bottom-0 left-0 w-full h-0.5 bg-gray-900 dark:bg-white scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
     </div>
   );
 }

--- a/frontend/pages/components/Hero.tsx
+++ b/frontend/pages/components/Hero.tsx
@@ -19,10 +19,10 @@ interface OrbConfig {
 }
 
 const palettes = [
-  'bg-gradient-to-br from-purple-500/40 to-fuchsia-500/40 dark:from-purple-500/60 dark:to-fuchsia-500/60',
-  'bg-gradient-to-br from-blue-500/40 to-cyan-500/40 dark:from-blue-500/60 dark:to-cyan-500/60',
-  'bg-gradient-to-br from-pink-500/40 to-rose-500/40 dark:from-pink-500/60 dark:to-rose-500/60',
-  'bg-gradient-to-br from-indigo-500/40 to-purple-500/40 dark:from-indigo-500/60 dark:to-purple-500/60',
+  'bg-gradient-to-br from-gray-400/60 to-gray-500/60 dark:from-white/30 dark:to-gray-300/30',
+  'bg-gradient-to-br from-gray-300/60 to-gray-400/60 dark:from-gray-200/30 dark:to-white/30',
+  'bg-gradient-to-br from-gray-500/60 to-gray-600/60 dark:from-gray-300/30 dark:to-gray-400/30',
+  'bg-gradient-to-br from-gray-400/60 to-gray-300/60 dark:from-white/30 dark:to-gray-200/30',
 ];
 
 export default function Hero() {
@@ -53,14 +53,14 @@ export default function Hero() {
 
   return (
     <div className="relative min-h-[calc(100vh-4rem)] flex items-center justify-center overflow-hidden px-4 sm:px-6 touch-pan-y">
-      <div className="absolute inset-0 bg-gradient-to-br from-purple-50 to-blue-50 dark:from-purple-900/20 dark:to-blue-900/20" />
+      <div className="absolute inset-0 bg-gradient-to-br from-gray-100 to-white dark:from-gray-900/40 dark:to-black/40" />
 
       <div className="relative z-10 max-w-4xl mx-auto text-center">
         <motion.h1
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.5 }}
-          className="text-4xl sm:text-6xl md:text-7xl font-bold mb-4 sm:mb-6 bg-gradient-to-r from-purple-600 via-pink-600 to-blue-600 bg-clip-text text-transparent"
+          className="text-4xl sm:text-6xl md:text-7xl font-bold mb-4 sm:mb-6 bg-gradient-to-r from-gray-900 to-gray-600 dark:from-white dark:to-gray-400 bg-clip-text text-transparent"
         >
           {config.hero.name}
         </motion.h1>
@@ -91,7 +91,7 @@ export default function Hero() {
         >
           <div className="relative mx-auto w-fit">
             <motion.div
-              className="absolute -inset-1 rounded-full bg-gradient-to-r from-purple-400/20 via-fuchsia-400/20 to-blue-400/20 blur-lg"
+              className="absolute -inset-1 rounded-full bg-gradient-to-r from-gray-400/20 via-gray-300/20 to-gray-400/20 dark:from-white/15 dark:via-gray-300/15 dark:to-white/15 blur-lg"
               animate={{ opacity: [0, 0.7, 0] }}
               transition={{ duration: 3, repeat: Infinity, delay: 1.5 }}
             />
@@ -109,7 +109,7 @@ export default function Hero() {
           {orbs.map((orb, i) => (
             <motion.div
               key={i}
-              className={`absolute w-48 h-48 rounded-full blur-2xl ${orb.palette}`}
+              className={`absolute w-48 h-48 rounded-full blur-xl ${orb.palette}`}
               animate={
                 isMobile
                   ? {
@@ -144,9 +144,9 @@ export default function Hero() {
             className="absolute inset-0 opacity-50 dark:opacity-70"
             animate={{
               background: [
-                'radial-gradient(circle at 20% 30%, rgba(147, 51, 234, 0.25) 0%, transparent 60%), radial-gradient(circle at 80% 70%, rgba(59, 130, 246, 0.25) 0%, transparent 60%)',
-                'radial-gradient(circle at 80% 60%, rgba(236, 72, 153, 0.25) 0%, transparent 60%), radial-gradient(circle at 20% 40%, rgba(59, 130, 246, 0.25) 0%, transparent 60%)',
-                'radial-gradient(circle at 20% 30%, rgba(147, 51, 234, 0.25) 0%, transparent 60%), radial-gradient(circle at 80% 70%, rgba(59, 130, 246, 0.25) 0%, transparent 60%)',
+                'radial-gradient(circle at 20% 30%, rgba(120, 120, 120, 0.28) 0%, transparent 60%), radial-gradient(circle at 80% 70%, rgba(160, 160, 160, 0.28) 0%, transparent 60%)',
+                'radial-gradient(circle at 80% 60%, rgba(140, 140, 140, 0.28) 0%, transparent 60%), radial-gradient(circle at 20% 40%, rgba(110, 110, 110, 0.28) 0%, transparent 60%)',
+                'radial-gradient(circle at 20% 30%, rgba(120, 120, 120, 0.28) 0%, transparent 60%), radial-gradient(circle at 80% 70%, rgba(160, 160, 160, 0.28) 0%, transparent 60%)',
               ],
             }}
             transition={{ duration: 15, repeat: Infinity, ease: 'easeInOut' }}

--- a/frontend/pages/components/InpersonaButton.tsx
+++ b/frontend/pages/components/InpersonaButton.tsx
@@ -26,7 +26,7 @@ const InpersonaButton: React.FC<InpersonaButtonProps> = ({
     <div className={`relative group ${className}`}>
       {/* Outer glow effect */}
       <motion.div
-        className="absolute inset-0 rounded-full bg-gradient-to-r from-violet-500/50 via-fuchsia-500/50 to-indigo-500/50 blur-lg opacity-75"
+        className="absolute inset-0 rounded-full bg-gradient-to-r from-gray-400/40 via-gray-500/40 to-gray-400/40 dark:from-white/20 dark:via-gray-300/20 dark:to-white/20 blur-lg opacity-75"
         initial={{ scale: 0.8, opacity: 0 }}
         animate={{ 
           scale: isPulsing ? [0.8, 1.1, 0.9] : 1,
@@ -41,7 +41,7 @@ const InpersonaButton: React.FC<InpersonaButtonProps> = ({
 
       <Link href="/loading">
         <motion.button
-          className="relative flex items-center gap-2 sm:gap-3 px-4 sm:px-6 py-2.5 sm:py-3.5 rounded-full bg-gradient-to-r from-violet-600 via-fuchsia-600 to-indigo-600 text-white shadow-lg hover:shadow-xl shadow-indigo-500/30 hover:shadow-indigo-500/40"
+          className="relative flex items-center gap-2 sm:gap-3 px-4 sm:px-6 py-2.5 sm:py-3.5 rounded-full bg-gray-900 text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 shadow-lg hover:shadow-xl shadow-black/20 dark:shadow-white/20"
           whileHover={{ scale: 1.05 }}
           whileTap={{ scale: 0.98 }}
           initial={{ opacity: 0, y: 20 }}
@@ -55,7 +55,7 @@ const InpersonaButton: React.FC<InpersonaButtonProps> = ({
         >
           {/* Animated icon container */}
           <motion.div
-            className="relative flex items-center justify-center bg-white/20 rounded-full p-1.5"
+            className="relative flex items-center justify-center bg-white/20 dark:bg-black/10 rounded-full p-1.5"
             animate={{ 
               rotate: isPulsing ? [0, 15, -15, 0] : 0,
             }}
@@ -65,8 +65,8 @@ const InpersonaButton: React.FC<InpersonaButtonProps> = ({
               ease: "easeInOut"
             }}
           >
-            <Bot size={16} className="text-white sm:hidden" />
-            <Bot size={18} className="text-white hidden sm:block" />
+            <Bot size={16} className="text-white dark:text-gray-900 sm:hidden" />
+            <Bot size={18} className="text-white dark:text-gray-900 hidden sm:block" />
             
             {/* Sparkle icon */}
             <motion.div 
@@ -82,8 +82,8 @@ const InpersonaButton: React.FC<InpersonaButtonProps> = ({
                 ease: "easeInOut"
               }}
             >
-              <Sparkles size={8} className="text-yellow-300 sm:hidden" />
-              <Sparkles size={10} className="text-yellow-300 hidden sm:block" />
+              <Sparkles size={8} className="text-white dark:text-gray-900 sm:hidden" />
+              <Sparkles size={10} className="text-white dark:text-gray-900 hidden sm:block" />
             </motion.div>
           </motion.div>
           
@@ -95,8 +95,8 @@ const InpersonaButton: React.FC<InpersonaButtonProps> = ({
             transition={{ type: "spring", stiffness: 300 }}
             className="ml-auto"
           >
-            <ArrowRight size={14} className="text-white/80 sm:hidden" />
-            <ArrowRight size={16} className="text-white/80 hidden sm:block" />
+            <ArrowRight size={14} className="text-white/80 dark:text-gray-900/80 sm:hidden" />
+            <ArrowRight size={16} className="text-white/80 dark:text-gray-900/80 hidden sm:block" />
           </motion.div>
         </motion.button>
       </Link>
@@ -107,7 +107,7 @@ const InpersonaButton: React.FC<InpersonaButtonProps> = ({
           {[...Array(5)].map((_, i) => (
             <motion.div
               key={i}
-              className="absolute h-1 w-1 sm:h-1.5 sm:w-1.5 rounded-full bg-indigo-300"
+              className="absolute h-1 w-1 sm:h-1.5 sm:w-1.5 rounded-full bg-gray-400 dark:bg-gray-500"
               initial={{ 
                 opacity: 0,
                 scale: 0,

--- a/frontend/pages/components/InpersonaChat.tsx
+++ b/frontend/pages/components/InpersonaChat.tsx
@@ -219,12 +219,12 @@ export default function InpersonaChat() {
   };
 
   return (
-    <div className="relative flex h-[100dvh] w-full flex-col overflow-hidden bg-gradient-to-br from-gray-50 to-blue-50 dark:from-gray-900 dark:to-blue-900">
+    <div className="relative flex h-[100dvh] w-full flex-col overflow-hidden bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black">
       {/* Top bar */}
       <div className="fixed inset-x-0 top-0 z-50 flex items-center justify-between bg-white/80 dark:bg-gray-900/80 backdrop-blur-sm py-2 px-4">
         <Link
           href="/"
-          className="whitespace-nowrap text-sm sm:text-base font-bold bg-gradient-to-r from-purple-600 via-pink-600 to-blue-600 bg-clip-text text-transparent"
+          className="whitespace-nowrap text-sm sm:text-base font-bold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-white dark:to-gray-400 bg-clip-text text-transparent"
         >
           {inpersona.homeLink}
         </Link>
@@ -232,7 +232,7 @@ export default function InpersonaChat() {
           <div className="flex items-center gap-2">
             <span
               className={`block h-2 w-2 rounded-full ${
-                isConnected ? 'bg-green-500' : 'bg-red-500'
+                isConnected ? 'bg-gray-900 dark:bg-white' : 'bg-gray-300 dark:bg-gray-600'
               }`}
             />
             <span className="text-xs text-gray-600 dark:text-gray-300">
@@ -281,7 +281,7 @@ export default function InpersonaChat() {
                         return !v;
                       });
                     }}
-                    activeClasses="bg-gradient-to-r from-purple-700 to-purple-500 text-white"
+                    activeClasses="bg-gray-900 text-white dark:bg-white dark:text-gray-900"
                   />
                 </Tooltip>
                 <Tooltip text={hydeToggle.tooltip}>
@@ -296,7 +296,7 @@ export default function InpersonaChat() {
                         return !v;
                       });
                     }}
-                    activeClasses="bg-gradient-to-r from-blue-700 to-blue-500 text-white"
+                    activeClasses="bg-gray-900 text-white dark:bg-white dark:text-gray-900"
                   />
                 </Tooltip>
               </div>
@@ -308,7 +308,7 @@ export default function InpersonaChat() {
                   icon={<Network size={12} />}
                   label={kgToggle.shortLabel}
                   onToggle={() => setUseKnowledgeGraph((v) => !v)}
-                  activeClasses="bg-gradient-to-r from-purple-700 to-purple-500 text-white"
+                  activeClasses="bg-gray-900 text-white dark:bg-white dark:text-gray-900"
                   compact
                 />
                 <ToggleButton
@@ -316,7 +316,7 @@ export default function InpersonaChat() {
                   icon={<Search size={12} />}
                   label={hydeToggle.shortLabel}
                   onToggle={() => setUseHydeQuery((v) => !v)}
-                  activeClasses="bg-gradient-to-r from-blue-700 to-blue-500 text-white"
+                  activeClasses="bg-gray-900 text-white dark:bg-white dark:text-gray-900"
                   compact
                 />
                 <button
@@ -343,10 +343,10 @@ export default function InpersonaChat() {
                 type="button"
                 onClick={submitDraft}
                 disabled={!isConnected || isLoading || !draftMessage.trim()}
-                className="ml-2 rounded-xl bg-gradient-to-br from-purple-600 to-blue-600 p-1.5 shadow-md transition-opacity hover:opacity-90 disabled:opacity-50"
+                className="ml-2 rounded-xl bg-gray-900 dark:bg-white p-1.5 shadow-md transition-opacity hover:opacity-90 disabled:opacity-50"
                 aria-label="Send"
               >
-                <Send size={20} className="text-white" />
+                <Send size={20} className="text-white dark:text-gray-900" />
               </button>
             </div>
           </div>
@@ -377,7 +377,7 @@ function EmptyState({
   const { inpersona } = config;
   return (
     <div className="flex min-h-[calc(100vh-240px)] flex-col items-center justify-center space-y-4 sm:space-y-6 px-4 mt-2 sm:mt-4">
-      <div className="h-24 w-24 sm:h-32 sm:w-32 animate-float rounded-full bg-gradient-to-br from-purple-600 to-blue-600 p-1 shadow-lg">
+      <div className="h-24 w-24 sm:h-32 sm:w-32 animate-float rounded-full bg-gradient-to-br from-gray-700 to-gray-900 dark:from-gray-300 dark:to-white p-1 shadow-lg">
         <img
           src={inpersona.avatar}
           alt="Yatharth"
@@ -394,7 +394,7 @@ function EmptyState({
               key={question}
               onClick={() => onSuggestionClick(question)}
               disabled={!isReady}
-              className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3 text-left text-sm sm:text-base text-gray-700 dark:text-gray-300 shadow-sm transition-all hover:border-purple-300 dark:hover:border-purple-600 hover:bg-gray-50 dark:hover:bg-gray-700 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50"
+              className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-3 text-left text-sm sm:text-base text-gray-700 dark:text-gray-300 shadow-sm transition-all hover:border-gray-400 dark:hover:border-gray-500 hover:bg-gray-50 dark:hover:bg-gray-700 hover:shadow-md disabled:cursor-not-allowed disabled:opacity-50"
             >
               {question}
             </button>
@@ -411,7 +411,7 @@ function MessageBubble({ message }: { message: Message }) {
       <div
         className={`max-w-[90%] sm:max-w-[85%] rounded-2xl p-3 sm:p-4 transition-all ${
           message.isUser
-            ? 'bg-gradient-to-br from-purple-600 to-blue-600 text-white shadow-lg'
+            ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900 shadow-lg'
             : 'bg-white dark:bg-gray-800 text-gray-800 dark:text-gray-200 shadow-md'
         }`}
       >

--- a/frontend/pages/components/InpersonaLoading.tsx
+++ b/frontend/pages/components/InpersonaLoading.tsx
@@ -28,7 +28,7 @@ export default function InpersonaLoading() {
   const progressDelay = FEATURE_BASE_DELAY + features.length * FEATURE_STEP;
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-gradient-to-br from-purple-900 via-blue-900 to-black p-4">
+    <div className="fixed inset-0 flex items-center justify-center bg-gradient-to-br from-gray-900 via-gray-950 to-black p-4">
       <div className="relative w-full max-w-[600px]">
         <motion.div
           initial={{ scale: 0, opacity: 0 }}
@@ -47,7 +47,7 @@ export default function InpersonaLoading() {
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.7 }}
-            className="mb-4 sm:mb-8 text-2xl sm:text-3xl font-bold bg-gradient-to-r from-purple-400 to-blue-400 bg-clip-text text-transparent"
+            className="mb-4 sm:mb-8 text-2xl sm:text-3xl font-bold bg-gradient-to-r from-white to-gray-400 bg-clip-text text-transparent"
           >
             {loadingTitle}
           </motion.h2>
@@ -63,7 +63,7 @@ export default function InpersonaLoading() {
                   transition={{ delay: FEATURE_BASE_DELAY + index * FEATURE_STEP }}
                   className="flex items-center gap-3 rounded-xl bg-white/10 backdrop-blur-sm p-3 sm:p-4"
                 >
-                  <div className="rounded-lg bg-gradient-to-br from-purple-500 to-blue-500 p-1.5 sm:p-2">
+                  <div className="rounded-lg bg-gradient-to-br from-gray-600 to-gray-800 p-1.5 sm:p-2">
                     <Icon className="h-5 w-5 sm:h-6 sm:w-6" />
                   </div>
                   <div className="text-left">
@@ -82,7 +82,7 @@ export default function InpersonaLoading() {
             transition={{ delay: progressDelay }}
           >
             <motion.div
-              className="h-full bg-gradient-to-r from-purple-500 via-blue-500 to-purple-500"
+              className="h-full bg-gradient-to-r from-gray-400 via-white to-gray-400"
               initial={{ width: '0%' }}
               animate={{ width: '100%' }}
               transition={{ duration: 1.5, delay: progressDelay, ease: 'easeInOut' }}
@@ -95,10 +95,10 @@ export default function InpersonaLoading() {
               initial={{ opacity: 0, scale: 0.9 }}
               animate={{ opacity: 1, scale: 1 }}
               whileHover={{ scale: 1.05 }}
-              className="group relative mt-4 sm:mt-8 px-6 sm:px-8 py-2.5 sm:py-3 rounded-full bg-gradient-to-r from-purple-500 to-blue-500 text-sm sm:text-base font-medium text-white shadow-lg"
+              className="group relative mt-4 sm:mt-8 px-6 sm:px-8 py-2.5 sm:py-3 rounded-full bg-white text-gray-900 hover:bg-gray-200 text-sm sm:text-base font-medium shadow-lg"
             >
               <motion.div
-                className="absolute inset-0 rounded-full bg-white opacity-20"
+                className="absolute inset-0 rounded-full bg-gray-900 opacity-20"
                 animate={{ scale: [1, 1.2, 1], opacity: [0.2, 0, 0.2] }}
                 transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}
               />

--- a/frontend/pages/components/Projects.tsx
+++ b/frontend/pages/components/Projects.tsx
@@ -31,7 +31,7 @@ export default function Projects() {
                 className="group relative flex h-full flex-col bg-white dark:bg-gray-900 rounded-2xl shadow-lg overflow-hidden hover:shadow-2xl transition-all duration-300 hover:-translate-y-1"
               >
                 <div className="relative h-48 overflow-hidden">
-                  <div className="absolute inset-0 z-10 bg-gradient-to-r from-purple-600/50 to-blue-600/50 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
+                  <div className="absolute inset-0 z-10 bg-gradient-to-r from-black/40 to-black/10 opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
                   {MediaComponent ? (
                     <MediaComponent />
                   ) : (
@@ -68,7 +68,7 @@ export default function Projects() {
                         href={project.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center text-sm font-medium text-purple-600 dark:text-purple-400 hover:text-purple-800 dark:hover:text-purple-300 transition-colors ml-auto"
+                        className="inline-flex items-center text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-gray-600 dark:hover:text-gray-300 transition-colors ml-auto"
                       >
                         <span>Live Demo</span>
                         <ExternalLink size={16} className="ml-1" />
@@ -77,7 +77,7 @@ export default function Projects() {
                   </div>
                 </div>
 
-                <div className="pointer-events-none absolute top-0 right-0 w-20 h-20 bg-gradient-to-br from-purple-600/20 to-blue-600/20 dark:from-purple-600/10 dark:to-blue-600/10 rotate-45 translate-x-10 -translate-y-10" />
+                <div className="pointer-events-none absolute top-0 right-0 w-20 h-20 bg-gradient-to-br from-gray-900/15 to-gray-500/10 dark:from-white/10 dark:to-white/5 rotate-45 translate-x-10 -translate-y-10" />
               </motion.article>
             );
           })}

--- a/frontend/pages/components/Skills.tsx
+++ b/frontend/pages/components/Skills.tsx
@@ -99,35 +99,21 @@ interface CategoryStyle {
   pattern: string;
 }
 
+// One shared monochrome scheme for every category — the emoji icon and title carry
+// the per-category identity, so the cards stay visually unified in black & white.
+const monochromeStyle: CategoryStyle = {
+  bg: 'bg-gradient-to-r from-gray-200/50 via-gray-100/20 to-gray-200/50 dark:from-gray-700/40 dark:via-gray-800/20 dark:to-gray-700/40',
+  border: 'border-gray-200 dark:border-gray-700',
+  textColor: 'text-gray-900 dark:text-gray-100',
+  glowOverlay: 'bg-gradient-to-r from-gray-400 to-gray-600 dark:from-gray-300 dark:to-gray-500',
+  pattern: 'bg-gray-500',
+};
+
 const categoryStyles: Record<SkillCategoryKey, CategoryStyle> = {
-  languages: {
-    bg: 'bg-gradient-to-r from-purple-600/10 via-purple-500/5 to-blue-600/10',
-    border: 'border-purple-200 dark:border-purple-800/50',
-    textColor: 'text-purple-600 dark:text-purple-400',
-    glowOverlay: 'bg-gradient-to-r from-purple-500 to-blue-500',
-    pattern: 'bg-purple-600',
-  },
-  technologies: {
-    bg: 'bg-gradient-to-r from-blue-600/10 via-blue-500/5 to-cyan-600/10',
-    border: 'border-blue-200 dark:border-blue-800/50',
-    textColor: 'text-blue-600 dark:text-blue-400',
-    glowOverlay: 'bg-gradient-to-r from-blue-500 to-cyan-500',
-    pattern: 'bg-blue-600',
-  },
-  databases: {
-    bg: 'bg-gradient-to-r from-green-600/10 via-green-500/5 to-teal-600/10',
-    border: 'border-green-200 dark:border-green-800/50',
-    textColor: 'text-green-600 dark:text-green-400',
-    glowOverlay: 'bg-gradient-to-r from-green-500 to-teal-500',
-    pattern: 'bg-green-600',
-  },
-  coreCompetencies: {
-    bg: 'bg-gradient-to-r from-pink-600/10 via-pink-500/5 to-rose-600/10',
-    border: 'border-pink-200 dark:border-pink-800/50',
-    textColor: 'text-pink-600 dark:text-pink-400',
-    glowOverlay: 'bg-gradient-to-r from-pink-500 to-rose-500',
-    pattern: 'bg-pink-600',
-  },
+  languages: monochromeStyle,
+  technologies: monochromeStyle,
+  databases: monochromeStyle,
+  coreCompetencies: monochromeStyle,
 };
 
 const containerVariants = {
@@ -218,7 +204,7 @@ function SkillCategoryView({
             <span className={isMobile ? 'text-xl' : 'text-2xl'}>{category.icon}</span>
           </div>
           <h3 className={isMobile ? 'text-lg font-bold' : 'text-xl font-bold'}>
-            <span className="bg-gradient-to-r from-purple-600 via-pink-600 to-blue-600 bg-clip-text text-transparent">
+            <span className="bg-gradient-to-r from-gray-900 to-gray-600 dark:from-white dark:to-gray-400 bg-clip-text text-transparent">
               {category.title}
             </span>
           </h3>
@@ -252,14 +238,14 @@ export default function Skills() {
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
       transition={{ duration: isMobile ? 0.5 : 0.7 }}
-      className={`relative overflow-hidden rounded-3xl border border-gray-200/50 dark:border-gray-700/50 bg-gradient-to-br from-white/80 to-gray-100/80 dark:from-gray-800/80 dark:to-gray-900/80 backdrop-blur-sm shadow-xl ${
+      className={`relative overflow-hidden rounded-3xl border border-gray-200/50 dark:border-gray-700/50 bg-gradient-to-br from-white/80 to-gray-100/80 dark:from-gray-800/80 dark:to-black/80 backdrop-blur-sm shadow-xl ${
         isMobile ? 'my-8 py-10' : 'my-12 sm:my-24 py-16 sm:py-24'
       }`}
     >
       {!isMobile && (
         <>
-          <div className="pointer-events-none absolute top-0 left-0 w-40 h-40 bg-purple-500/10 rounded-full blur-3xl" />
-          <div className="pointer-events-none absolute bottom-0 right-0 w-60 h-60 bg-blue-500/10 rounded-full blur-3xl" />
+          <div className="pointer-events-none absolute top-0 left-0 w-40 h-40 bg-gray-500/10 dark:bg-white/5 rounded-full blur-3xl" />
+          <div className="pointer-events-none absolute bottom-0 right-0 w-60 h-60 bg-gray-500/10 dark:bg-white/5 rounded-full blur-3xl" />
         </>
       )}
 
@@ -272,7 +258,7 @@ export default function Skills() {
           className={`text-center ${isMobile ? 'mb-8' : 'mb-16'}`}
         >
           <h2
-            className={`mb-4 font-extrabold bg-gradient-to-r from-purple-600 via-pink-600 to-blue-600 bg-clip-text text-transparent ${
+            className={`mb-4 font-extrabold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-white dark:to-gray-400 bg-clip-text text-transparent ${
               isMobile ? 'text-3xl' : 'text-4xl sm:text-5xl'
             }`}
           >

--- a/frontend/pages/components/Testimonials.tsx
+++ b/frontend/pages/components/Testimonials.tsx
@@ -38,7 +38,7 @@ function TestimonialCard({
           <button
             type="button"
             onClick={() => setIsExpanded((v) => !v)}
-            className="mt-2 rounded px-2 py-0.5 text-sm font-medium text-purple-600 dark:text-purple-400 hover:underline focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
+            className="mt-2 rounded px-2 py-0.5 text-sm font-medium text-gray-900 dark:text-gray-100 hover:underline focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
           >
             {isExpanded ? 'Read less' : 'Read more'}
           </button>
@@ -47,11 +47,11 @@ function TestimonialCard({
 
       <div className="mt-auto flex items-center border-t border-gray-100 dark:border-gray-700 pt-4">
         {imageUrl ? (
-          <div className="mr-4 h-14 w-14 overflow-hidden rounded-full ring-2 ring-purple-500 ring-offset-2 dark:ring-offset-gray-800">
+          <div className="mr-4 h-14 w-14 overflow-hidden rounded-full ring-2 ring-gray-900 dark:ring-white ring-offset-2 dark:ring-offset-gray-800">
             <img src={imageUrl} alt={name} className="h-full w-full object-cover" />
           </div>
         ) : (
-          <div className="mr-4 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-purple-500 to-indigo-600 text-xl font-bold text-white shadow-md">
+          <div className="mr-4 flex h-14 w-14 items-center justify-center rounded-full bg-gradient-to-br from-gray-700 to-gray-900 dark:from-gray-300 dark:to-white text-xl font-bold text-white dark:text-gray-900 shadow-md">
             {name.charAt(0)}
           </div>
         )}
@@ -63,7 +63,7 @@ function TestimonialCard({
                 href={linkedinUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-[#0A66C2] hover:text-[#004182] dark:hover:text-[#4593de] transition-colors"
+                className="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white transition-colors"
                 aria-label={`${name}'s LinkedIn profile`}
               >
                 <SiLinkedin className="h-5 w-5" />
@@ -153,11 +153,11 @@ export default function Testimonials() {
       onMouseEnter={() => setAutoRotate(false)}
       onMouseLeave={() => setAutoRotate(true)}
       aria-label="Testimonials"
-      className="relative my-12 sm:my-24 overflow-hidden rounded-3xl bg-gradient-to-b from-purple-50/60 to-white/60 dark:from-gray-900/60 dark:to-gray-800/60 backdrop-blur-sm py-16 sm:py-24 shadow-xl"
+      className="relative my-12 sm:my-24 overflow-hidden rounded-3xl bg-gradient-to-b from-gray-100/60 to-white/60 dark:from-gray-900/60 dark:to-gray-800/60 backdrop-blur-sm py-16 sm:py-24 shadow-xl"
     >
       <div className="pointer-events-none absolute inset-0 overflow-hidden opacity-10">
-        <div className="absolute -top-40 -right-40 h-80 w-80 rounded-full bg-purple-300/30" />
-        <div className="absolute -bottom-40 -left-40 h-96 w-96 rounded-full bg-blue-300/30" />
+        <div className="absolute -top-40 -right-40 h-80 w-80 rounded-full bg-gray-400/30 dark:bg-white/10" />
+        <div className="absolute -bottom-40 -left-40 h-96 w-96 rounded-full bg-gray-400/30 dark:bg-white/10" />
       </div>
 
       <div className="relative z-10 mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -210,9 +210,9 @@ export default function Testimonials() {
                 type="button"
                 onClick={prev}
                 aria-label="Previous testimonials"
-                className="group rounded-full bg-white dark:bg-gray-700 p-3 shadow-md transition-colors hover:bg-purple-100 dark:hover:bg-purple-900/30"
+                className="group rounded-full bg-white dark:bg-gray-700 p-3 shadow-md transition-colors hover:bg-gray-200 dark:hover:bg-gray-600"
               >
-                <ChevronLeft className="h-5 w-5 text-purple-600 dark:text-purple-400 transition-transform group-hover:scale-110" />
+                <ChevronLeft className="h-5 w-5 text-gray-900 dark:text-gray-100 transition-transform group-hover:scale-110" />
               </button>
 
               <div className="my-4 flex gap-3 sm:my-0">
@@ -225,8 +225,8 @@ export default function Testimonials() {
                     aria-current={currentPage === idx ? 'true' : 'false'}
                     className={`rounded transition-all duration-300 ${
                       currentPage === idx
-                        ? 'h-2 w-8 bg-purple-600 dark:bg-purple-500'
-                        : 'h-2 w-2 bg-gray-300 dark:bg-gray-600 hover:bg-purple-400 dark:hover:bg-purple-700'
+                        ? 'h-2 w-8 bg-gray-900 dark:bg-white'
+                        : 'h-2 w-2 bg-gray-300 dark:bg-gray-600 hover:bg-gray-500 dark:hover:bg-gray-400'
                     }`}
                   />
                 ))}
@@ -236,9 +236,9 @@ export default function Testimonials() {
                 type="button"
                 onClick={next}
                 aria-label="Next testimonials"
-                className="group rounded-full bg-white dark:bg-gray-700 p-3 shadow-md transition-colors hover:bg-purple-100 dark:hover:bg-purple-900/30"
+                className="group rounded-full bg-white dark:bg-gray-700 p-3 shadow-md transition-colors hover:bg-gray-200 dark:hover:bg-gray-600"
               >
-                <ChevronRight className="h-5 w-5 text-purple-600 dark:text-purple-400 transition-transform group-hover:scale-110" />
+                <ChevronRight className="h-5 w-5 text-gray-900 dark:text-gray-100 transition-transform group-hover:scale-110" />
               </button>
             </div>
           )}

--- a/frontend/pages/components/Tooltip.tsx
+++ b/frontend/pages/components/Tooltip.tsx
@@ -11,10 +11,10 @@ export default function Tooltip({ text, children }: TooltipProps) {
       {children}
       <div
         role="tooltip"
-        className="invisible absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded-xl bg-gradient-to-br from-purple-600 to-blue-600 px-4 py-3 text-sm text-white opacity-0 shadow-lg transition-all duration-300 group-hover:visible group-hover:opacity-100"
+        className="invisible absolute bottom-full left-1/2 -translate-x-1/2 mb-2 whitespace-nowrap rounded-xl bg-gray-900 dark:bg-gray-700 px-4 py-3 text-sm text-white opacity-0 shadow-lg transition-all duration-300 group-hover:visible group-hover:opacity-100"
       >
         {text}
-        <div className="absolute left-1/2 top-full -mt-2 -translate-x-1/2 border-4 border-transparent border-t-blue-600" />
+        <div className="absolute left-1/2 top-full -mt-2 -translate-x-1/2 border-4 border-transparent border-t-gray-900 dark:border-t-gray-700" />
         <div className="absolute left-0 bottom-[-8px] h-2 w-full" />
       </div>
     </div>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -49,12 +49,12 @@ export default function Home() {
               transition={{ duration: 0.5, delay: 0.3 }}
               whileHover={{
                 scale: 1.02,
-                boxShadow: '0 8px 25px rgba(147, 51, 234, 0.3)',
+                boxShadow: '0 8px 25px rgba(0, 0, 0, 0.25)',
                 transition: { duration: 0.2 },
               }}
               whileTap={{ scale: 0.98 }}
               onClick={() => setIsContactModalOpen(true)}
-              className="inline-block rounded-full bg-gradient-to-r from-purple-600 to-blue-600 px-8 py-4 font-medium text-white transition-shadow hover:shadow-lg"
+              className="inline-block rounded-full bg-gray-900 text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 px-8 py-4 font-medium transition-colors hover:shadow-lg"
             >
               {contact.ctaLabel}
             </motion.button>
@@ -98,7 +98,7 @@ function AboutSection() {
             transition={{ duration: 0.6, delay: 0.3 }}
             className="relative mt-8 md:mt-0"
           >
-            <div className="absolute inset-0 rounded-2xl bg-gradient-to-r from-purple-600 to-blue-600 opacity-30 blur-lg" />
+            <div className="absolute inset-0 rounded-2xl bg-gradient-to-r from-gray-400 to-gray-600 dark:from-gray-600 dark:to-gray-800 opacity-30 blur-lg" />
             <img
               src={about.image}
               alt={about.title}

--- a/frontend/pages/inpersona/knowledgegraph.tsx
+++ b/frontend/pages/inpersona/knowledgegraph.tsx
@@ -28,19 +28,19 @@ export default function KnowledgeGraph() {
   };
 
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-br from-gray-50 to-blue-50 dark:from-gray-900 dark:to-blue-950">
+    <div className="min-h-screen flex flex-col bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black">
       {/* Enhanced Navigation */}
       <nav className="backdrop-blur-sm bg-white/30 dark:bg-black/30 border-b border-gray-200/20 dark:border-gray-700/20 sticky top-0 z-50">
         <div className="max-w-7xl mx-auto px-2 sm:px-4 lg:px-8">
           <div className="flex justify-between items-center h-14 sm:h-16">
             <Link 
               href="/inpersona" 
-              className="flex items-center space-x-1 sm:space-x-2 bg-gradient-to-r from-purple-600 via-pink-600 to-blue-600 bg-clip-text text-transparent font-bold hover:opacity-80 transition-opacity text-sm sm:text-base"
+              className="flex items-center space-x-1 sm:space-x-2 bg-gradient-to-r from-gray-900 to-gray-600 dark:from-white dark:to-gray-400 bg-clip-text text-transparent font-bold hover:opacity-80 transition-opacity text-sm sm:text-base"
             >
-              <ArrowLeft className="w-4 h-4 sm:w-5 sm:h-5 stroke-purple-600 dark:stroke-purple-400" />
+              <ArrowLeft className="w-4 h-4 sm:w-5 sm:h-5 stroke-gray-900 dark:stroke-white" />
               <span>Back to Chat</span>
             </Link>
-            <h1 className="text-lg sm:text-xl font-bold bg-gradient-to-r from-purple-600 via-pink-600 to-blue-600 bg-clip-text text-transparent hidden sm:block">
+            <h1 className="text-lg sm:text-xl font-bold bg-gradient-to-r from-gray-900 to-gray-600 dark:from-white dark:to-gray-400 bg-clip-text text-transparent hidden sm:block">
               Knowledge Graph Explorer
             </h1>
             <button

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -240,12 +240,12 @@
 }
 
 .html-content a {
-  color: #3b82f6;
+  color: #111827;
   text-decoration: underline;
 }
 
 .dark .html-content a {
-  color: #60a5fa;
+  color: #e5e7eb;
 }
 
 .html-content hr {


### PR DESCRIPTION
## What

Converts the portfolio + Inpersona UI from the multi-color gradient theme to a black & white (grayscale) system. The light/dark toggle keeps working — B&W maps cleanly onto both.

## Changes (20 files)

- **Headings** — grayscale gradient (`gray-900→gray-600` light, `white→gray-400` dark)
- **Primary buttons** — high-contrast inverted pills (black-on-white / white-on-black)
- **Backgrounds, accents, links, hovers, orbs, glows** — reduced to grays
- **Inpersona nav link** — color-cycling gradient → grayscale shimmer
- **Skills** — four color-coded categories unified into one monochrome card style
- **Open-Notif SVG diagram, company logos, chat links** — grayscale
- **Chat status dot** — green/red → bright/dim gray (label still reads Connected/Disconnected)
- **Hero orbs** — reduced blur (`blur-2xl`→`blur-xl`) + higher opacity so the drift animation is visible

## Verification

- `tsc --noEmit` passes
- `next build` passes (all 20 routes prerender)
- Grep confirms zero color-name Tailwind classes remain
- Browser-checked the home hero and chat page in both light and dark mode; SVG colors confirmed grayscale via the live DOM

## Note

The four Skills category headers use emoji (💻 🔧 🗄️ 🚀) from `index.json` — the OS renders those in color and CSS can't recolor them. Happy to swap for the existing monochrome icon fallbacks (`FaCode`/`FaTools`/`FaDatabase`/`FaRocket`) if you want it fully black & white.
