### PR TITLE
frontend: remove Resume download button from nav

### DIFF
--- a/frontend/pages/components/Header.tsx
+++ b/frontend/pages/components/Header.tsx
@@ -25,7 +25,6 @@ export default function Header() {
   const handleNavClick =
     (item: NavItem, closeMenu = false) =>
     (e: MouseEvent<HTMLAnchorElement>) => {
-      if (item.isDownload) return;
       e.preventDefault();
       navigateTo(item.url);
       if (closeMenu) setIsMenuOpen(false);
@@ -79,7 +78,6 @@ export default function Header() {
                   <a
                     key={item.title}
                     href={item.url}
-                    download={item.isDownload}
                     onClick={handleNavClick(item, true)}
                     className="text-gray-700 dark:text-gray-200 hover:text-black dark:hover:text-white transition-colors"
                   >
@@ -106,7 +104,6 @@ function NavLink({
     <div className="group relative">
       <a
         href={item.url}
-        download={item.isDownload}
         onClick={onClick}
         className="whitespace-nowrap font-medium text-gray-700 dark:text-gray-200 hover:text-black dark:hover:text-white transition-colors"
       >

--- a/frontend/pages/index.json
+++ b/frontend/pages/index.json
@@ -7,7 +7,6 @@
     { "title": "About", "url": "#about" },
     { "title": "Projects", "url": "#projects" },
     { "title": "Contact", "url": "#contact" },
-    { "title": "Resume", "url": "/Yatharth-Kapadia-Resume.pdf", "isDownload": true },
     { "title": "Inpersona", "url": "/inpersona" }
   ],
   "hero": {

--- a/frontend/types/config.ts
+++ b/frontend/types/config.ts
@@ -3,7 +3,6 @@ import configJson from '../pages/index.json';
 export interface NavItem {
   title: string;
   url: string;
-  isDownload?: boolean;
 }
 
 export interface Skill {


### PR DESCRIPTION
## What

Removes the **Resume** download button from the site navigation, as requested.

- Drops the `Resume` entry from `navigation` in `index.json` (it was the only `isDownload` item) — gone from both desktop and mobile nav.
- Cleans up the now-unused `isDownload` plumbing: the `NavItem.isDownload` type field and the `download={...}` attribute + click guard in `Header.tsx`. All remaining nav items now use the same preventDefault + SPA-navigate path.

## Not touched

The `/Yatharth-Kapadia-Resume.pdf` asset stays in `frontend/public/` — it's just no longer linked from the UI (still reachable by direct URL). Say the word if you want the file deleted too.

## Verification

- `next build` passes (all routes prerender)
- No remaining `isDownload`/`resume` references in source
- Verified in the browser: nav now reads **About · Projects · Contact · Inpersona**

Nav before: About · Projects · Contact · ~~Resume~~ · Inpersona