### PR TITLE
frontend: remove em-dashes from all user-facing copy

### DIFF
--- a/frontend/components/animations/TaskbundlePoster.tsx
+++ b/frontend/components/animations/TaskbundlePoster.tsx
@@ -51,7 +51,7 @@ export default function TaskbundlePoster() {
       <circle cx="132" cy="103" r="7" fill="#febc2e" />
       <circle cx="156" cy="103" r="7" fill="#28c840" />
       <text x="480" y="109" textAnchor="middle" fontSize="20" fill="#8b8bb0">
-        taskbundle — task run
+        taskbundle · task run
       </text>
 
       {/* Session */}

--- a/frontend/pages/components/Footer.tsx
+++ b/frontend/pages/components/Footer.tsx
@@ -35,7 +35,7 @@ export default function Footer() {
           ))}
         </div>
         <p className="text-sm text-gray-500 dark:text-gray-400">
-          © {year} — Developed by{' '}
+          © {year} · Developed by{' '}
           <a
             href={config.site.developerUrl}
             target="_blank"

--- a/frontend/pages/index.json
+++ b/frontend/pages/index.json
@@ -306,7 +306,7 @@
       },
       {
         "title": "Taskbundle",
-        "description": "An evaluation environment for coding agents: SWE-bench-style tasks solved blind, graded against hidden tests — tamper-proof scoring that pinpoints every fix and every regression.",
+        "description": "An evaluation environment for coding agents: SWE-bench-style tasks solved blind and graded against hidden tests. Tamper-proof scoring that pinpoints every fix and every regression.",
         "github": "https://github.com/yatharthk2/taskbundle",
         "media": "taskbundlePoster"
       },

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -31,7 +31,7 @@ export default function Home() {
     <Layout>
       <Seo
         title="Yatharth Kapadia · AI/ML Engineer"
-        description="Portfolio of Yatharth Kapadia, AI/ML engineer in San Francisco. Production LLM and RAG systems — and Inpersona, a self-hosted AI chatbot that answers questions as him."
+        description="Portfolio of Yatharth Kapadia, AI/ML engineer in San Francisco. Production LLM and RAG systems, plus Inpersona, a self-hosted AI chatbot that answers questions as him."
       />
       <Head>
         <script

--- a/frontend/pages/inpersona.tsx
+++ b/frontend/pages/inpersona.tsx
@@ -6,7 +6,7 @@ export default function Inpersona() {
     <>
       <Seo
         title="Inpersona · Chat with Yatharth's AI"
-        description="Ask Inpersona anything about Yatharth Kapadia's work — a RAG chatbot built on FastAPI, LlamaIndex, and ChromaDB that answers as him, streaming over WebSockets."
+        description="Ask Inpersona anything about Yatharth Kapadia's work. A RAG chatbot built on FastAPI, LlamaIndex, and ChromaDB that answers as him, streaming over WebSockets."
         path="/inpersona"
       />
       <InpersonaChat />

--- a/frontend/pages/inpersona/knowledgegraph.tsx
+++ b/frontend/pages/inpersona/knowledgegraph.tsx
@@ -32,7 +32,7 @@ export default function KnowledgeGraph() {
     <div className="min-h-screen flex flex-col bg-gradient-to-br from-gray-50 to-gray-100 dark:from-gray-900 dark:to-black">
       <Seo
         title="Knowledge Graph Explorer · Inpersona"
-        description="Explore the entity graph behind Inpersona — a knowledge graph extracted from Yatharth Kapadia's resume and project docs."
+        description="Explore the entity graph behind Inpersona: a knowledge graph extracted from Yatharth Kapadia's resume and project docs."
         path="/inpersona/knowledgegraph"
       />
       {/* Enhanced Navigation */}

--- a/frontend/pages/loading.tsx
+++ b/frontend/pages/loading.tsx
@@ -6,7 +6,7 @@ export default function LoadingPage() {
     <>
       <Seo
         title="Inpersona · Yatharth Kapadia"
-        description="Inpersona is warming up — a RAG chatbot that answers as Yatharth Kapadia."
+        description="Inpersona is warming up. A RAG chatbot that answers as Yatharth Kapadia."
         path="/loading"
         noindex
       />


### PR DESCRIPTION
Removes em-dashes (—) from every visible string, per preference.

- Taskbundle project description (split into two sentences)
- Four page meta descriptions: home, /inpersona, /loading, /inpersona/knowledgegraph
- Footer credit: "© {year} · Developed by …" (middot)
- Poster terminal title bar: "taskbundle · task run" (middot)

En-dashes in experience date ranges (e.g. "Oct 2025 – Present") are left as-is — correct range typography, not em-dashes. Internal code comments still contain em-dashes (invisible to visitors); not touched here.

Verified live: the rendered home page contains zero em-dashes. `tsc` + `next build` pass.