### PR TITLE
frontend: add LinkedIn link to Harsha testimonial

### DIFF
--- a/frontend/pages/index.json
+++ b/frontend/pages/index.json
@@ -347,7 +347,8 @@
         "role": "Co-Founder",
         "company": "Moss (YC F25)",
         "content": "I hired Yatharth as the first engineer at Moss, and he quickly became the person I'd hand the hardest problem to and stop worrying about: relentlessly hardworking, completely dependable, with work that always came back done, and done well. He owns problems end to end and learns fast, but what really sets him apart is that he leaves everything he touches better than he found it and holds himself to a higher bar than anyone asks of him. He's sharp, low-ego, and a real pleasure to build with. He'll make any team better, and I recommend him without reservation.",
-        "imageUrl": "/Testimonial/harsha.jpeg"
+        "imageUrl": "/Testimonial/harsha.jpeg",
+        "linkedinUrl": "https://www.linkedin.com/in/imharshanalluru/"
       },
       {
         "name": "Yogesh Shinde",


### PR DESCRIPTION
Wires up `linkedinUrl` on the Harsha Nalluru testimonial (added in #30) so his card shows the LinkedIn icon like the other three.

- `frontend/pages/index.json` — adds `"linkedinUrl": "https://www.linkedin.com/in/imharshanalluru/"`.

Verified in the local dev server: Harsha's card now renders the LinkedIn icon (`aria-label: "Harsha Nalluru's LinkedIn profile"`, correct href), no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)