### PR TITLE
frontend: make Inpersona loading screen theme-aware

### DIFF
--- a/frontend/pages/components/InpersonaLoading.tsx
+++ b/frontend/pages/components/InpersonaLoading.tsx
@@ -28,26 +28,26 @@ export default function InpersonaLoading() {
   const progressDelay = FEATURE_BASE_DELAY + features.length * FEATURE_STEP;
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-gradient-to-br from-gray-900 via-gray-950 to-black p-4">
+    <div className="fixed inset-0 flex items-center justify-center bg-gradient-to-br from-gray-50 via-white to-gray-100 dark:from-gray-900 dark:via-gray-950 dark:to-black p-4">
       <div className="relative w-full max-w-[600px]">
         <motion.div
           initial={{ scale: 0, opacity: 0 }}
           animate={{ scale: 1, opacity: 1 }}
           transition={{ duration: 0.5 }}
-          className="absolute inset-0 rounded-3xl bg-white/5 backdrop-blur-xl"
+          className="absolute inset-0 rounded-3xl border border-gray-200/70 dark:border-white/10 bg-gray-900/5 dark:bg-white/5 backdrop-blur-xl"
         />
 
         <motion.div
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           transition={{ delay: 0.5 }}
-          className="relative p-4 sm:p-8 text-center text-white"
+          className="relative p-4 sm:p-8 text-center text-gray-900 dark:text-white"
         >
           <motion.h2
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ delay: 0.7 }}
-            className="mb-4 sm:mb-8 text-2xl sm:text-3xl font-bold tracking-tight text-white"
+            className="mb-4 sm:mb-8 text-2xl sm:text-3xl font-bold tracking-tight text-gray-900 dark:text-white"
           >
             {loadingTitle}
           </motion.h2>
@@ -61,14 +61,16 @@ export default function InpersonaLoading() {
                   initial={{ opacity: 0, x: -20 }}
                   animate={{ opacity: 1, x: 0 }}
                   transition={{ delay: FEATURE_BASE_DELAY + index * FEATURE_STEP }}
-                  className="flex items-center gap-3 rounded-xl bg-white/10 backdrop-blur-sm p-3 sm:p-4"
+                  className="flex items-center gap-3 rounded-xl border border-gray-200/70 dark:border-transparent bg-gray-900/5 dark:bg-white/10 backdrop-blur-sm p-3 sm:p-4"
                 >
                   <div className="rounded-lg bg-gradient-to-br from-gray-600 to-gray-800 p-1.5 sm:p-2">
-                    <Icon className="h-5 w-5 sm:h-6 sm:w-6" />
+                    <Icon className="h-5 w-5 sm:h-6 sm:w-6 text-white" />
                   </div>
                   <div className="text-left">
                     <h3 className="text-sm sm:text-base font-semibold">{feature.title}</h3>
-                    <p className="text-xs sm:text-sm text-gray-300">{feature.description}</p>
+                    <p className="text-xs sm:text-sm text-gray-600 dark:text-gray-300">
+                      {feature.description}
+                    </p>
                   </div>
                 </motion.div>
               );
@@ -76,13 +78,13 @@ export default function InpersonaLoading() {
           </div>
 
           <motion.div
-            className="mt-4 sm:mt-8 h-1 overflow-hidden rounded-full bg-white/20"
+            className="mt-4 sm:mt-8 h-1 overflow-hidden rounded-full bg-gray-900/10 dark:bg-white/20"
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: progressDelay }}
           >
             <motion.div
-              className="h-full bg-gradient-to-r from-gray-400 via-white to-gray-400"
+              className="h-full bg-gradient-to-r from-gray-500 via-gray-900 to-gray-500 dark:from-gray-400 dark:via-white dark:to-gray-400"
               initial={{ width: '0%' }}
               animate={{ width: '100%' }}
               transition={{ duration: 1.5, delay: progressDelay, ease: 'easeInOut' }}
@@ -95,10 +97,10 @@ export default function InpersonaLoading() {
               initial={{ opacity: 0, scale: 0.9 }}
               animate={{ opacity: 1, scale: 1 }}
               whileHover={{ scale: 1.05 }}
-              className="group relative mt-4 sm:mt-8 px-6 sm:px-8 py-2.5 sm:py-3 rounded-full bg-white text-gray-900 hover:bg-gray-200 text-sm sm:text-base font-medium shadow-lg"
+              className="group relative mt-4 sm:mt-8 px-6 sm:px-8 py-2.5 sm:py-3 rounded-full bg-gray-900 text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 text-sm sm:text-base font-medium shadow-lg"
             >
               <motion.div
-                className="absolute inset-0 rounded-full bg-gray-900 opacity-20"
+                className="absolute inset-0 rounded-full bg-white dark:bg-gray-900 opacity-20"
                 animate={{ scale: [1, 1.2, 1], opacity: [0.2, 0, 0.2] }}
                 transition={{ duration: 2, repeat: Infinity, ease: 'easeInOut' }}
               />


### PR DESCRIPTION
## Problem

The "Initializing Inpersona" loading screen (`InpersonaLoading`, shown at `/loading`) was hardcoded dark — dark gradient background, `text-white`, white-tinted panel and feature tiles. In **light mode** it stayed dark while the rest of the site switched, the same class of bug just fixed for the Testimonials section (#32).

## Fix

Added light/dark variants throughout:
- Background gradient: `from-gray-50 via-white to-gray-100 dark:from-gray-900 dark:via-gray-950 dark:to-black`
- Panel + feature tiles: light frosted (`bg-gray-900/5` + `border-gray-200/70`) in light, the original `bg-white/...` under `dark:`
- Heading / text: `text-gray-900 dark:text-white`, descriptions `text-gray-600 dark:text-gray-300`
- Progress bar + CTA button: dark-on-light in light mode (`bg-gray-900 text-white`), light-on-dark under `dark:`
- Accent icon boxes kept their dark gradient with an explicit `text-white` icon (so the icon stays legible in both themes)

## Verified locally (both themes)

- **Light**: light gradient background, dark heading/text, dark "Ready when you are" button, legible tiles — screenshotted.
- **Dark**: unchanged from before (dark gradient `gray-900`→black, white text) — confirmed via computed styles.

CSS-class-only change; no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)