### PR TITLE
frontend: thread hero aurora accent through the home page

### DIFF
--- a/frontend/components/primitives/InpersonaNavLink.tsx
+++ b/frontend/components/primitives/InpersonaNavLink.tsx
@@ -9,8 +9,9 @@ interface InpersonaNavLinkProps {
 }
 
 /**
- * The grayscale-shimmering "Inpersona" pill used in both the desktop and
- * mobile navs. The shimmer is one wide gradient animated via CSS
+ * The aurora-shimmering "Inpersona" pill used in both the desktop and
+ * mobile navs (teal→mint→green, echoing the hero cloud). The shimmer is one
+ * wide gradient animated via CSS
  * background-position (`.nav-pill-shimmer` in globals.css) — cheap on the
  * compositor, unlike interpolating gradient strings per frame on the main
  * thread inside a sticky header. Two layers: a blurred halo and a crisp

--- a/frontend/pages/components/Achievements.tsx
+++ b/frontend/pages/components/Achievements.tsx
@@ -6,9 +6,11 @@ import SectionHeading from '../../components/primitives/SectionHeading';
 import config from '../../types/config';
 import { asIcon, type Icon } from '../../types/icons';
 
-// All company marks render in a single grayscale tone to keep the section monochrome;
-// the icon shapes themselves stay recognizable.
-const ICON_TONE = 'text-gray-700 dark:text-gray-300';
+// All company marks render in a single grayscale tone to keep the section
+// monochrome at rest; they pick up the aurora accent on card hover, matching
+// the rest of the page. The icon shapes themselves stay recognizable.
+const ICON_TONE =
+  'text-gray-700 dark:text-gray-300 transition-colors group-hover:text-aurora-600 dark:group-hover:text-aurora-400';
 const companyIcons: Record<string, { Icon: Icon; className: string }> = {
   dell: { Icon: asIcon(SiDell), className: ICON_TONE },
   nvidia: { Icon: asIcon(SiNvidia), className: ICON_TONE },
@@ -38,11 +40,11 @@ export default function Achievements() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ delay: index * 0.08 }}
-                className="group relative flex h-full flex-col bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm hover:shadow-md p-6 overflow-hidden transition-all duration-200 hover:-translate-y-1"
+                className="group relative flex h-full flex-col bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm p-6 overflow-hidden transition-all duration-200 hover:-translate-y-1 hover:border-aurora-500/50 dark:hover:border-aurora-400/40 hover:shadow-md hover:shadow-aurora-500/10"
               >
                 <div className="flex items-start mb-4">
                   {iconConfig && (
-                    <div className="p-3 rounded-full bg-gray-100 dark:bg-gray-800 mr-4">
+                    <div className="p-3 rounded-full bg-gray-100 dark:bg-gray-800 mr-4 transition-colors group-hover:bg-aurora-500/10 dark:group-hover:bg-aurora-400/10">
                       <iconConfig.Icon className={`text-2xl ${iconConfig.className}`} />
                     </div>
                   )}
@@ -64,7 +66,7 @@ export default function Achievements() {
                       href={item.link}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="inline-flex items-center text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                      className="inline-flex items-center text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-aurora-600 dark:hover:text-aurora-400 transition-colors"
                     >
                       Learn more
                       <svg

--- a/frontend/pages/components/Experience.tsx
+++ b/frontend/pages/components/Experience.tsx
@@ -20,7 +20,7 @@ export default function Experience() {
               whileInView={{ opacity: 1, y: 0 }}
               viewport={{ once: true }}
               transition={{ delay: index * 0.1 }}
-              className="group relative flex h-full flex-col bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden hover:shadow-md transition-all duration-200 hover:-translate-y-1"
+              className="group relative flex h-full flex-col bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden transition-all duration-200 hover:-translate-y-1 hover:border-aurora-500/50 dark:hover:border-aurora-400/40 hover:shadow-md hover:shadow-aurora-500/10"
             >
               <div
                 className={`relative h-40 overflow-hidden ${
@@ -62,7 +62,7 @@ export default function Experience() {
                     href={exp.companyUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-2 mt-auto pt-4 text-sm text-gray-900 dark:text-gray-100 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                    className="inline-flex items-center gap-2 mt-auto pt-4 text-sm text-gray-900 dark:text-gray-100 hover:text-aurora-600 dark:hover:text-aurora-400 transition-colors"
                   >
                     <ExternalLink size={14} />
                     <span>Visit Company Page</span>

--- a/frontend/pages/components/Footer.tsx
+++ b/frontend/pages/components/Footer.tsx
@@ -28,7 +28,7 @@ export default function Footer() {
               target="_blank"
               rel="noreferrer"
               aria-label={label}
-              className="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors duration-200"
+              className="text-gray-500 hover:text-aurora-600 dark:text-gray-400 dark:hover:text-aurora-400 transition-colors duration-200"
             >
               <Icon className="w-6 h-6" />
             </a>
@@ -40,7 +40,7 @@ export default function Footer() {
             href={config.site.developerUrl}
             target="_blank"
             rel="noreferrer"
-            className="hover:text-gray-700 dark:hover:text-gray-300 transition-colors"
+            className="hover:text-aurora-600 dark:hover:text-aurora-400 transition-colors"
           >
             {config.site.name}
           </a>

--- a/frontend/pages/components/Header.tsx
+++ b/frontend/pages/components/Header.tsx
@@ -79,7 +79,7 @@ export default function Header() {
                     key={item.title}
                     href={item.url}
                     onClick={handleNavClick(item, true)}
-                    className="text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white transition-colors"
+                    className="text-gray-700 dark:text-gray-300 hover:text-aurora-600 dark:hover:text-aurora-400 transition-colors"
                   >
                     {item.title}
                   </a>
@@ -105,11 +105,11 @@ function NavLink({
       <a
         href={item.url}
         onClick={onClick}
-        className="whitespace-nowrap font-medium text-gray-700 dark:text-gray-300 hover:text-black dark:hover:text-white transition-colors"
+        className="whitespace-nowrap font-medium text-gray-700 dark:text-gray-300 hover:text-aurora-600 dark:hover:text-aurora-400 transition-colors"
       >
         {item.title}
       </a>
-      <div className="absolute bottom-0 left-0 w-full h-0.5 bg-gray-900 dark:bg-white scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
+      <div className="absolute bottom-0 left-0 w-full h-0.5 bg-aurora-600 dark:bg-aurora-400 scale-x-0 group-hover:scale-x-100 transition-transform origin-left" />
     </div>
   );
 }

--- a/frontend/pages/components/Projects.tsx
+++ b/frontend/pages/components/Projects.tsx
@@ -30,7 +30,7 @@ export default function Projects() {
                 whileInView={{ opacity: 1, y: 0 }}
                 viewport={{ once: true }}
                 transition={{ delay: index * 0.1 }}
-                className="group relative flex h-full flex-col bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden hover:shadow-md transition-all duration-200 hover:-translate-y-1"
+                className="group relative flex h-full flex-col bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden transition-all duration-200 hover:-translate-y-1 hover:border-aurora-500/50 dark:hover:border-aurora-400/40 hover:shadow-md hover:shadow-aurora-500/10"
               >
                 <div className="relative h-48 overflow-hidden">
                   {MediaComponent ? (
@@ -58,7 +58,7 @@ export default function Projects() {
                         href={project.github}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors"
+                        className="inline-flex items-center text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-aurora-600 dark:hover:text-aurora-400 transition-colors"
                       >
                         <Github size={16} className="mr-1" />
                         <span>Source</span>
@@ -69,7 +69,7 @@ export default function Projects() {
                         href={project.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-gray-600 dark:hover:text-gray-300 transition-colors ml-auto"
+                        className="inline-flex items-center text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-aurora-600 dark:hover:text-aurora-400 transition-colors ml-auto"
                       >
                         <span>Live Demo</span>
                         <ExternalLink size={16} className="ml-1" />

--- a/frontend/pages/components/Skills.tsx
+++ b/frontend/pages/components/Skills.tsx
@@ -114,9 +114,9 @@ function SkillTag({ skill, category }: { skill: Skill; category: SkillCategoryKe
       variants={itemVariants}
       whileHover={{ scale: 1.03 }}
       transition={{ type: 'spring', stiffness: 400, damping: 25 }}
-      className="flex items-center gap-2 rounded-full border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-1.5 transition-colors hover:border-gray-500 dark:hover:border-gray-400"
+      className="group flex items-center gap-2 rounded-full border border-gray-300 dark:border-gray-700 bg-white dark:bg-gray-900 px-3 py-1.5 transition-colors hover:border-aurora-500 dark:hover:border-aurora-400"
     >
-      <Icon className="text-base text-gray-700 dark:text-gray-300" />
+      <Icon className="text-base text-gray-700 dark:text-gray-300 transition-colors group-hover:text-aurora-600 dark:group-hover:text-aurora-400" />
       <span className="font-mono text-xs font-medium text-gray-700 dark:text-gray-300">
         {skill.name}
       </span>

--- a/frontend/pages/components/Testimonials.tsx
+++ b/frontend/pages/components/Testimonials.tsx
@@ -43,7 +43,7 @@ function TestimonialCard({
             type="button"
             onClick={() => setIsExpanded((v) => !v)}
             aria-expanded={isExpanded}
-            className="mt-2 -ml-2 rounded px-2 py-0.5 text-sm font-medium text-gray-900 dark:text-white hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900"
+            className="mt-2 -ml-2 rounded px-2 py-0.5 text-sm font-medium text-gray-900 dark:text-white hover:text-aurora-600 dark:hover:text-aurora-400 hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-aurora-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900"
           >
             {isExpanded ? 'Read less' : 'Read more'}
           </button>
@@ -68,7 +68,7 @@ function TestimonialCard({
                 href={linkedinUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-gray-400 hover:text-gray-900 dark:hover:text-white transition-colors"
+                className="text-gray-400 hover:text-aurora-600 dark:hover:text-aurora-400 transition-colors"
                 aria-label={`${name}'s LinkedIn profile`}
               >
                 <SiLinkedin className="h-5 w-5" />
@@ -228,7 +228,7 @@ export default function Testimonials() {
                 type="button"
                 onClick={prev}
                 aria-label="Previous testimonials"
-                className="group rounded-full bg-gray-900/5 hover:bg-gray-900/10 dark:bg-white/10 dark:hover:bg-white/20 p-3 transition-colors"
+                className="group rounded-full bg-gray-900/5 hover:bg-aurora-500/10 dark:bg-white/10 dark:hover:bg-aurora-400/20 p-3 transition-colors"
               >
                 <ChevronLeft className="h-5 w-5 text-gray-900 dark:text-white transition-transform group-hover:scale-110" />
               </button>
@@ -243,8 +243,8 @@ export default function Testimonials() {
                     aria-current={currentPage === idx ? 'true' : 'false'}
                     className={`rounded transition-all duration-300 ${
                       currentPage === idx
-                        ? 'h-2 w-8 bg-gray-900 dark:bg-white'
-                        : 'h-2 w-2 bg-gray-900/30 hover:bg-gray-900/60 dark:bg-white/30 dark:hover:bg-white/60'
+                        ? 'h-2 w-8 bg-aurora-600 dark:bg-aurora-400'
+                        : 'h-2 w-2 bg-gray-900/30 hover:bg-aurora-500/60 dark:bg-white/30 dark:hover:bg-aurora-400/60'
                     }`}
                   />
                 ))}
@@ -254,7 +254,7 @@ export default function Testimonials() {
                 type="button"
                 onClick={next}
                 aria-label="Next testimonials"
-                className="group rounded-full bg-gray-900/5 hover:bg-gray-900/10 dark:bg-white/10 dark:hover:bg-white/20 p-3 transition-colors"
+                className="group rounded-full bg-gray-900/5 hover:bg-aurora-500/10 dark:bg-white/10 dark:hover:bg-aurora-400/20 p-3 transition-colors"
               >
                 <ChevronRight className="h-5 w-5 text-gray-900 dark:text-white transition-transform group-hover:scale-110" />
               </button>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -79,7 +79,7 @@ export default function Home() {
               whileHover={{ scale: 1.03 }}
               whileTap={{ scale: 0.97 }}
               onClick={() => setIsContactModalOpen(true)}
-              className="inline-block rounded-full bg-gray-900 text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 px-8 py-4 font-medium shadow-md hover:shadow-lg transition-all duration-200"
+              className="inline-block rounded-full bg-gray-900 text-white hover:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 px-8 py-4 font-medium shadow-md hover:shadow-lg hover:shadow-aurora-500/40 transition-all duration-200"
             >
               {contact.ctaLabel}
             </motion.button>
@@ -123,7 +123,7 @@ function AboutSection() {
             transition={{ duration: 0.6, delay: 0.3 }}
             className="relative mt-8 md:mt-0"
           >
-            <div className="absolute inset-0 rounded-2xl bg-gradient-to-r from-gray-400 to-gray-600 dark:from-gray-600 dark:to-gray-800 opacity-30 blur-lg" />
+            <div className="absolute inset-0 rounded-2xl bg-gradient-to-r from-aurora-400 to-aurora-600 dark:from-aurora-700 dark:to-aurora-500 opacity-30 blur-lg" />
             <img
               src={about.image}
               alt={about.title}

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -98,7 +98,7 @@
    background-position — compositor-cheap, unlike interpolating gradient
    strings per frame in JS. */
 .nav-pill-shimmer {
-  background: linear-gradient(110deg, #525252, #e5e5e5, #737373, #d4d4d4, #525252);
+  background: linear-gradient(110deg, #0f6b70, #7be0a6, #2fb866, #168a5f, #0f6b70);
   background-size: 300% 100%;
   animation: pill-shimmer 6s linear infinite;
 }
@@ -152,13 +152,13 @@
   height: 8px;
   width: 8px;
   margin: 0 2px;
-  background-color: rgba(115, 115, 115, 0.7);
+  background-color: rgba(22, 138, 95, 0.75);
   border-radius: 50%;
   opacity: 0.4;
 }
 
 .dark .typing-indicator span {
-  background-color: rgba(163, 163, 163, 0.7);
+  background-color: rgba(52, 211, 153, 0.8);
 }
 
 .typing-indicator span:nth-child(1) {
@@ -255,12 +255,12 @@
 }
 
 .html-content a {
-  color: #171717;
+  color: #0f6b70;
   text-decoration: underline;
 }
 
 .dark .html-content a {
-  color: #e5e5e5;
+  color: #7be0a6;
 }
 
 .html-content hr {

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -21,6 +21,22 @@ module.exports = {
 			// neutral scale so "black & white" is actually black & white.
 			colors: {
 				gray: colors.neutral,
+				// Aurora accent — drawn from the hero dither-cloud's teal→green→mint
+				// ramp (see DitherCanvas PALETTES.aurora). Single source of truth for
+				// every accent on the page so the home reads as one composition with
+				// the hero. Use ~400 on dark, ~600/700 on light for contrast.
+				aurora: {
+					50: '#e2fbef',
+					100: '#bfe3dc',
+					200: '#9ee5c4',
+					300: '#7be0a6',
+					400: '#34d399',
+					500: '#2fb866',
+					600: '#168a5f',
+					700: '#0f6b70',
+					800: '#125a63',
+					900: '#0c4f6a',
+				},
 			},
 		},
 	},


### PR DESCRIPTION
Carry the hero dither-cloud's teal/green/mint ramp into the rest of the
home as accents over the monochrome base. Adds a shared `aurora` Tailwind
scale and applies it to the nav-pill shimmer, chat typing dots and links,
nav and footer hovers, the About glow, the Contact CTA hover, and
card/link/icon accents across Experience, Projects, Skills, Achievements,
and Testimonials. Base text, surfaces, and the hero stay unchanged.
