### PR TITLE
frontend: stop home page components flickering on first load

### DIFF
--- a/frontend/components/primitives/SectionCard.tsx
+++ b/frontend/components/primitives/SectionCard.tsx
@@ -30,8 +30,8 @@ export default function SectionCard({
   return (
     <motion.section
       id={id}
-      initial={{ opacity: 0, y: 24 }}
-      whileInView={{ opacity: 1, y: 0 }}
+      initial={{ opacity: 0 }}
+      whileInView={{ opacity: 1 }}
       viewport={{ once: true, margin: '-50px' }}
       transition={{ duration: 0.6, ease: 'easeOut' }}
       className={`relative ${spacing} ${className}`}

--- a/frontend/components/primitives/SectionHeading.tsx
+++ b/frontend/components/primitives/SectionHeading.tsx
@@ -34,8 +34,8 @@ export default function SectionHeading({
 
   return (
     <Component
-      initial={{ opacity: 0, y: -16 }}
-      whileInView={{ opacity: 1, y: 0 }}
+      initial={{ opacity: 0 }}
+      whileInView={{ opacity: 1 }}
       viewport={{ once: true }}
       transition={{ duration: 0.5, delay: 0.1 }}
       className={`${sizeClasses[size]} ${alignment} font-bold tracking-tight text-gray-900 dark:text-white ${className}`}

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -4,6 +4,18 @@ export default function Document() {
   return (
     <Html lang="en" className="scroll-smooth">
       <Head>
+        {/* Anti-FOUC: set the theme class on <html> before first paint so the
+            page never renders in the default (light) theme and then flips to
+            dark on hydration. That flip animated the cards' transition-colors
+            light→dark while titles flipped instantly, flashing the text. Must
+            mirror ThemeContext's logic exactly (localStorage 'theme', else the
+            OS preference) or the two would briefly disagree. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              "(function(){try{var t=localStorage.getItem('theme');var d=window.matchMedia('(prefers-color-scheme: dark)').matches;if((t||(d?'dark':'light'))==='dark'){document.documentElement.classList.add('dark');}}catch(e){}})();",
+          }}
+        />
         <link rel="icon" href="/favicon.ico" sizes="32x32" />
         <link rel="icon" href="/icon.svg" type="image/svg+xml" />
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />

--- a/frontend/pages/components/Achievements.tsx
+++ b/frontend/pages/components/Achievements.tsx
@@ -36,8 +36,8 @@ export default function Achievements() {
             return (
               <motion.article
                 key={item.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
+                initial={{ opacity: 0 }}
+                whileInView={{ opacity: 1 }}
                 viewport={{ once: true }}
                 transition={{ delay: index * 0.08 }}
                 className="group relative flex h-full flex-col bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm p-6 overflow-hidden transition-all duration-200 hover:-translate-y-1 hover:border-aurora-500/50 dark:hover:border-aurora-400/40 hover:shadow-md hover:shadow-aurora-500/10"

--- a/frontend/pages/components/Experience.tsx
+++ b/frontend/pages/components/Experience.tsx
@@ -16,8 +16,8 @@ export default function Experience() {
           {items.map((exp, index) => (
             <motion.article
               key={`${exp.company}-${exp.period}`}
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
+              initial={{ opacity: 0 }}
+              whileInView={{ opacity: 1 }}
               viewport={{ once: true }}
               transition={{ delay: index * 0.1 }}
               className="group relative flex h-full flex-col bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden transition-all duration-200 hover:-translate-y-1 hover:border-aurora-500/50 dark:hover:border-aurora-400/40 hover:shadow-md hover:shadow-aurora-500/10"

--- a/frontend/pages/components/Projects.tsx
+++ b/frontend/pages/components/Projects.tsx
@@ -26,8 +26,8 @@ export default function Projects() {
             return (
               <motion.article
                 key={project.title}
-                initial={{ opacity: 0, y: 20 }}
-                whileInView={{ opacity: 1, y: 0 }}
+                initial={{ opacity: 0 }}
+                whileInView={{ opacity: 1 }}
                 viewport={{ once: true }}
                 transition={{ delay: index * 0.1 }}
                 className="group relative flex h-full flex-col bg-white dark:bg-gray-900 rounded-2xl border border-gray-200 dark:border-gray-800 shadow-sm overflow-hidden transition-all duration-200 hover:-translate-y-1 hover:border-aurora-500/50 dark:hover:border-aurora-400/40 hover:shadow-md hover:shadow-aurora-500/10"

--- a/frontend/pages/components/Skills.tsx
+++ b/frontend/pages/components/Skills.tsx
@@ -99,10 +99,9 @@ const containerVariants = {
 };
 
 const itemVariants = {
-  hidden: { opacity: 0, y: 10 },
+  hidden: { opacity: 0 },
   visible: {
     opacity: 1,
-    y: 0,
     transition: { type: 'spring' as const, stiffness: 200, damping: 25 },
   },
 };

--- a/frontend/pages/components/Testimonials.tsx
+++ b/frontend/pages/components/Testimonials.tsx
@@ -21,9 +21,9 @@ function TestimonialCard({
 
   return (
     <motion.div
-      initial={{ opacity: 0, y: 20 }}
-      animate={{ opacity: 1, y: 0 }}
-      exit={{ opacity: 0, y: -20 }}
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
       transition={{ duration: 0.5 }}
       className="relative mx-4 flex h-full flex-col rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 p-8 shadow-sm"
     >
@@ -175,8 +175,8 @@ export default function Testimonials() {
               switches with the theme), so the title follows the same light/dark
               treatment as every other section heading. */}
           <motion.h2
-            initial={{ opacity: 0, y: -16 }}
-            whileInView={{ opacity: 1, y: 0 }}
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5, delay: 0.1 }}
             className="mb-6 text-center text-3xl sm:text-4xl font-bold tracking-tight text-gray-900 dark:text-white"
@@ -203,9 +203,9 @@ export default function Testimonials() {
                 {visibleTestimonials.map((testimonial, index) => (
                   <motion.div
                     key={`${currentIndex}-${index}`}
-                    initial={{ opacity: 0, x: 50 }}
-                    animate={{ opacity: 1, x: 0 }}
-                    exit={{ opacity: 0, x: -50 }}
+                    initial={{ opacity: 0 }}
+                    animate={{ opacity: 1 }}
+                    exit={{ opacity: 0 }}
                     transition={{ duration: 0.5, delay: index * 0.1 }}
                     className={`w-full ${
                       displayCount === 3

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -72,8 +72,8 @@ export default function Home() {
             </motion.p>
             <motion.button
               type="button"
-              initial={{ opacity: 0, y: 20 }}
-              whileInView={{ opacity: 1, y: 0 }}
+              initial={{ opacity: 0 }}
+              whileInView={{ opacity: 1 }}
               viewport={{ once: true }}
               transition={{ duration: 0.5, delay: 0.3 }}
               whileHover={{ scale: 1.03 }}
@@ -103,8 +103,8 @@ function AboutSection() {
         <SectionHeading className="mb-8 sm:mb-12">{about.title}</SectionHeading>
         <div className="grid grid-cols-1 items-center gap-8 sm:gap-12 md:grid-cols-2">
           <motion.div
-            initial={{ opacity: 0, x: -30 }}
-            whileInView={{ opacity: 1, x: 0 }}
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
             transition={{ duration: 0.6, delay: 0.2 }}
             className="space-y-4 sm:space-y-6"
@@ -117,8 +117,8 @@ function AboutSection() {
             </p>
           </motion.div>
           <motion.div
-            initial={{ opacity: 0, x: 30 }}
-            whileInView={{ opacity: 1, x: 0 }}
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
             viewport={{ once: true }}
             transition={{ duration: 0.6, delay: 0.3 }}
             className="relative mt-8 md:mt-0"


### PR DESCRIPTION
Two fixes for the first-load flicker:

- Set the theme class on <html> before first paint via an inline script in
  _document.tsx, so the page no longer renders light and then flips to dark on
  hydration. That flip animated the cards' background transition while the title
  text flipped instantly, briefly washing out the titles.

- Make the scroll-reveal entrances fade in place by dropping the y/x translate
  (keeping the opacity fade) on SectionCard, SectionHeading, the Experience,
  Projects, Achievements and Skills cards, the About columns, the Contact
  button, and the Testimonials carousel. They no longer start offset and slide
  into position, and the nested section plus card slides no longer compound.
  The hero's own entrance is unchanged.
