### PR TITLE
frontend: add a PyPI link to the Taskbundle project card

### DIFF
--- a/frontend/pages/components/Projects.tsx
+++ b/frontend/pages/components/Projects.tsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { ExternalLink, Github } from 'lucide-react';
+import { ExternalLink, Github, Package } from 'lucide-react';
 import SectionCard from '../../components/primitives/SectionCard';
 import SectionHeading from '../../components/primitives/SectionHeading';
 import OpenNotifAnimation from '../../components/animations/OpenNotifAnimation';
@@ -73,6 +73,17 @@ export default function Projects() {
                       >
                         <span>Live Demo</span>
                         <ExternalLink size={16} className="ml-1" />
+                      </a>
+                    )}
+                    {project.pypi && (
+                      <a
+                        href={project.pypi}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="ml-auto inline-flex items-center text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-aurora-600 dark:hover:text-aurora-400 transition-colors"
+                      >
+                        <Package size={16} className="mr-1" />
+                        <span>PyPI</span>
                       </a>
                     )}
                   </div>

--- a/frontend/pages/index.json
+++ b/frontend/pages/index.json
@@ -308,6 +308,7 @@
         "title": "Taskbundle",
         "description": "An evaluation environment for coding agents: SWE-bench-style tasks solved blind and graded against hidden tests. Tamper-proof scoring that pinpoints every fix and every regression.",
         "github": "https://github.com/yatharthk2/taskbundle",
+        "pypi": "https://pypi.org/project/taskbundle/",
         "media": "taskbundlePoster"
       },
       {

--- a/frontend/types/config.ts
+++ b/frontend/types/config.ts
@@ -49,6 +49,7 @@ export interface ProjectItem {
   description: string;
   github?: string;
   url?: string;
+  pypi?: string;
   image?: string;
   media?: 'openNotifAnimation' | 'taskbundlePoster';
 }


### PR DESCRIPTION
Add an optional `pypi` field to ProjectItem and render a "PyPI" link (Package
icon, aurora hover) in the project card footer when present. Set it on
Taskbundle, pointing at https://pypi.org/project/taskbundle/.
