### PR TITLE
backend: support a configurable persona prompt via PROMPT_PATH

### DIFF
--- a/.claude/skills/add-persona.md
+++ b/.claude/skills/add-persona.md
@@ -1,0 +1,137 @@
+# Add a second Inpersona persona (process-per-persona)
+
+Run a second person's Inpersona chatbot alongside Yatharth's on the same Hetzner
+box. Each persona is its own backend container off the **same image** (no second
+build, so the disk constraint is respected), with its own documents, prompt,
+indices, and subdomain. Good for 1 (tight for 2) extra personas on the CX23;
+beyond that, do the multi-tenant single-process refactor instead.
+
+## What's shared vs per-persona
+
+| Shared | Per-persona |
+|---|---|
+| The Docker image (`inpersona-backend:latest`) | Documents (`documents-<p>/`) |
+| The Caddy container + Redis container | System prompt (`personas/<p>.prompt.txt` + `PROMPT_PATH`) |
+| The Hetzner box's RAM (~787 MiB resident each) | Indices (own `storage` + `chroma_db` volumes) |
+| API keys, if you reuse `.env` (shared rate limit) | Redis logical DB (`/1`, `/2`, …) and subdomain |
+
+The only code dependency is `PROMPT_PATH` (already in `settings.py` /
+`query_engine.py`): unset = Yatharth's built-in prompt; set = read that file,
+hard-failing if it's missing/empty so a persona never silently answers as
+Yatharth.
+
+## Inputs you need first
+
+1. The person's name + background (to write the prompt).
+2. Their docs (resume text + project notes).
+3. Their subdomain, e.g. `api.janedoe.com`, with an **A record → 178.104.211.36**.
+4. Their site origin(s) for CORS, e.g. `https://janedoe.com`.
+
+## Steps (example persona: `jane`)
+
+All paths are relative to `deploy/` on the server (`/opt/odyssey/deploy`).
+
+1. **Prompt** — copy `backend/chat/prompt.py`'s string into
+   `deploy/personas/jane.prompt.txt` and rewrite the identity (name, roles,
+   education, companies, employment auth, contact, examples). Keep the HTML
+   formatting + topic-filter rules verbatim; the frontend renders the output
+   with `dangerouslySetInnerHTML`, so the output contract must not change.
+
+2. **Documents** — put her resume/project text in `deploy/documents-jane/`.
+
+3. **Compose service** — add to `deploy/docker-compose.yml` under `services:`:
+
+   ```yaml
+     backend-jane:
+       image: inpersona-backend:latest   # reuse the image backend builds — no second build
+       restart: unless-stopped
+       mem_limit: 1200m                   # lower than backend's 2560m to avoid overcommit on 3.7 GiB
+       mem_reservation: 768m
+       cpus: 1.0
+       env_file:
+         - .env                           # reuses Yatharth's GROQ/Gemini keys (shared rate limit)
+       environment:
+         REDIS_URL: redis://redis:6379/1  # SEPARATE logical DB → no cache cross-contamination
+         HOST: 0.0.0.0
+         PORT: 8000
+         PROMPT_PATH: /app/persona.prompt.txt
+         ALLOWED_ORIGINS: https://janedoe.com,https://www.janedoe.com
+       volumes:
+         - backend_jane_storage:/app/storage
+         - backend_jane_chroma:/app/chroma_db
+         - backend_jane_hfcache:/app/.cache/huggingface
+         - ./documents-jane:/app/documents:ro
+         - ./personas/jane.prompt.txt:/app/persona.prompt.txt:ro
+       depends_on:
+         backend:
+           condition: service_healthy     # start only after the first persona is warm → avoids cold-start OOM
+         redis:
+           condition: service_started
+       networks:
+         - inpersona
+   ```
+
+   Add the new named volumes under `volumes:`:
+
+   ```yaml
+     backend_jane_storage:
+     backend_jane_chroma:
+     backend_jane_hfcache:
+   ```
+
+   For the `service_healthy` gate to work, add a healthcheck to the existing
+   `backend` service (uses the already-present `/ready` endpoint, which 503s
+   until the RAG stack is built):
+
+   ```yaml
+       healthcheck:
+         test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/ready').status==200 else 1)"]
+         interval: 10s
+         timeout: 5s
+         retries: 30
+         start_period: 120s
+   ```
+
+4. **Caddy route** — add a site block to `deploy/Caddyfile`:
+
+   ```
+   api.janedoe.com {
+       encode zstd gzip
+       reverse_proxy backend-jane:8000 {
+           transport http {
+               keepalive 5m
+               keepalive_idle_conns 10
+           }
+       }
+       log { output stdout; format console; level INFO }
+   }
+   ```
+
+5. **Deploy** — from `/opt/odyssey/deploy`:
+
+   ```bash
+   docker compose up -d            # builds backend image once; backend-jane reuses it
+   docker compose logs -f backend-jane
+   ```
+
+   The healthcheck staggers startup so the two backends never cold-start (peak
+   memory) simultaneously. Confirm her prompt loaded: look for
+   `Loaded persona system prompt from /app/persona.prompt.txt` in the logs.
+
+6. **Her frontend** — set `NEXT_PUBLIC_INPERSONA_WS_URL=wss://api.janedoe.com/chat`.
+
+## Gotchas
+
+- **Redis DB isolation is mandatory.** The cache is keyed only by the
+  normalized question (`odyssey:cache:` prefix, no persona namespace). Without a
+  separate `REDIS_URL` DB index, "where are you based?" could return the wrong
+  persona's cached answer. Use `/1`, `/2`, … per persona.
+- **RAM:** two backends ≈ 1.6 GiB + caddy/redis/OS ≈ 2.4 GiB of 3.7 GiB. Fits,
+  but the box already touches swap. A **third** persona needs a bigger box.
+- **No rebuild for the second persona** — `backend-jane` references the existing
+  image, so `docker compose up -d` won't trigger the CUDA/torch rebuild that the
+  disk constraint can't accommodate. Only the `backend` service builds.
+- **Shared API keys = shared rate limit.** If her traffic matters, give
+  `backend-jane` its own `env_file` with separate `GROQ_API_KEY` /
+  `Google_Gemini_API_KEY`.
+- **Reindex after doc edits:** `docker compose restart backend-jane`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,7 @@ Theme state is React Context ([`frontend/context/ThemeContext.tsx`](frontend/con
 For step-by-step playbooks see [`.claude/skills/`](.claude/skills/):
 - `redeploy-backend.md` — pushing backend code changes to Hetzner
 - `update-inpersona-kb.md` — refreshing the RAG knowledge base
+- `add-persona.md` — deploying a second person's Inpersona persona (process-per-persona) on the same box
 - `start-local-stack.md` — bringing up frontend + backend for local development
 - `diagnose-inpersona.md` — debugging chat issues (rate limits, WebSocket failures, etc.)
 - `manage-ionos-dns.md` — DNS changes at IONOS

--- a/backend/chat/query_engine.py
+++ b/backend/chat/query_engine.py
@@ -23,12 +23,36 @@ GENERIC_TIMEOUT = "Sorry, that took too long. Please try asking again."
 _FALLBACK = "I apologize, but I couldn't generate a response to your question."
 
 
+def _load_system_prompt(settings) -> str:
+    """Resolve the persona system prompt.
+
+    PROMPT_PATH unset (the default) keeps Yatharth's built-in prompt. When set,
+    the prompt is read from that file so a second persona can run off the same
+    image with its own identity. A configured-but-unreadable/empty path is a
+    hard error on purpose: silently falling back to the built-in prompt would
+    make one persona answer as someone else.
+    """
+    path = getattr(settings, "prompt_path", None)
+    if not path:
+        return contextualized_query
+    try:
+        with open(path, encoding="utf-8") as f:
+            text = f.read().strip()
+    except OSError as e:
+        raise RuntimeError(f"PROMPT_PATH={path!r} could not be read: {e}") from e
+    if not text:
+        raise RuntimeError(f"PROMPT_PATH={path!r} is empty")
+    logger.info("Loaded persona system prompt from %s", path)
+    return text
+
+
 class QueryEngine:
     """Manages query processing and streaming responses."""
 
     def __init__(self, graph_manager, cache_manager: CacheManager | None = None):
         self.graph_manager = graph_manager
         self.cache_manager = cache_manager
+        self.system_prompt = _load_system_prompt(graph_manager.settings)
         self.query_engine_KG = None
         self.query_engine_vector = None
         self.hyde_engine_KG = None
@@ -113,7 +137,7 @@ class QueryEngine:
             recent_history = chat.to_list()[-8:]
 
             query_context = (
-                contextualized_query
+                self.system_prompt
                 + "\n".join(
                     f"{msg['role'].capitalize()}: {msg['content']}" for msg in recent_history
                 )

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -39,6 +39,10 @@ class PropertyGraphSettings:
     storage_dir: str = "./storage"
     chroma_db_path: str = "./chroma_db"
     graph_file: str = "./kg.html"
+    # Optional override for the persona system prompt. Unset -> the built-in
+    # Yatharth prompt (chat/prompt.py). Set to a mounted file path to run a
+    # second persona off the same image with its own identity.
+    prompt_path: str | None = None
 
     # --- chunking + embedding ----------------------------------------------
     # chunk_size=800 keeps a whole job/project (and its sub-bullets) together
@@ -126,6 +130,7 @@ class PropertyGraphSettings:
                 overrides[attr] = int(value)
 
         _str("PDF_DIRECTORY", "pdf_directory")
+        _str("PROMPT_PATH", "prompt_path")
         _str("REDIS_URL", "redis_url")
         _str("DEFAULT_MODEL_PROVIDER", "default_model_provider")
         _str("HOST", "host")


### PR DESCRIPTION
## What & why

Enables running a **second Inpersona persona for someone else** on the existing Hetzner box, off the **same image** (no rebuild, so it stays within the box's disk constraint). The only code dependency for that is making the system prompt configurable; everything else a persona needs is config, volumes, and a Caddy route.

This PR is scoped to the **enabling change only**. The actual persona files (a friend's documents, prompt, compose service, Caddy block) are a follow-up once their name/domain/origin are known.

## Changes

- **`backend/settings.py`** — add an optional `prompt_path` field + `PROMPT_PATH` env wiring.
- **`backend/chat/query_engine.py`** — add `_load_system_prompt()`; the engine now uses `self.system_prompt`. When `PROMPT_PATH` is set it reads the prompt from that file; it **hard-fails** if the path is missing or empty, so a persona can never silently fall back to answering as Yatharth.
- **`.claude/skills/add-persona.md`** — new runbook for the process-per-persona deploy (own documents, prompt, indices, Redis DB, Caddy route), matched to the real `docker-compose.yml` / `Caddyfile`.
- **`CLAUDE.md`** — list the new skill.

## Backward compatibility

`PROMPT_PATH` defaults to unset → the existing deployment keeps using the built-in `chat/prompt.py` prompt with identical behavior. The change is purely additive.

## Verification

Tested the loader's four paths against the venv:

- unset → returns the built-in Yatharth prompt
- `PROMPT_PATH` set → reads + returns the file's content
- bad path → raises (never silently falls back)
- empty file → raises

`ruff check` and `ruff format --check` pass on both changed files.

## Deploy / capacity notes (for the follow-up)

- Each backend process loads its own ~787 MiB (embedding model + indices). Two ≈ 2.4 GiB of the box's 3.7 GiB. Fine for **one** extra persona; a third needs a bigger box.
- The runbook isolates the per-persona Redis cache via a separate logical DB (`redis://redis:6379/1`), since the cache is keyed only by the normalized question.
- Startup is staggered (healthcheck + `depends_on: service_healthy`) so the two backends don't cold-start their index builds simultaneously and OOM the box.
- The second persona reuses the existing Groq/Gemini keys (shared rate limit).

## Not included (needs inputs)

`deploy/personas/<name>.prompt.txt`, `deploy/documents-<name>/`, the `backend-<name>` compose service, and the Caddy site block — these need the friend's name/background, subdomain, and site origin.
