### PR TITLE
deploy: add Nupur Kalele as a second Inpersona persona

### DIFF
--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -23,3 +23,24 @@ api.yatharthk.com {
         level INFO
     }
 }
+
+# Second persona (Nupur Kalele) — temporary subdomain under yatharthk.com until
+# she has her own domain. Needs an A record: nupur-api.yatharthk.com -> the
+# server's public IP, then Caddy fetches the cert automatically. To move her to
+# her own domain later, just change this block's hostname.
+nupur-api.yatharthk.com {
+    encode zstd gzip
+
+    reverse_proxy backend-nupur:8000 {
+        transport http {
+            keepalive 5m
+            keepalive_idle_conns 10
+        }
+    }
+
+    log {
+        output stdout
+        format console
+        level INFO
+    }
+}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -45,6 +45,15 @@ services:
     mem_limit: 2560m       # embedding model + torch + Chroma, with rebuild headroom
     mem_reservation: 1g
     cpus: 1.5
+    healthcheck:
+      # /ready 503s until the RAG stack is built. backend-nupur gates on this so
+      # the two backends never cold-start their index builds simultaneously and
+      # OOM the box.
+      test: ["CMD", "python", "-c", "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://localhost:8000/ready').status==200 else 1)"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 120s
     env_file:
       - .env
     environment:
@@ -64,6 +73,36 @@ services:
       - ./documents:/app/documents:ro
     depends_on:
       - redis
+    networks:
+      - inpersona
+
+  # Second persona (Nupur Kalele). Same image as `backend`, no separate build —
+  # just its own documents, prompt, indices, and Redis logical DB.
+  backend-nupur:
+    image: inpersona-backend:latest   # reuse the image `backend` builds — no second build
+    restart: unless-stopped
+    mem_limit: 1200m                   # lower than backend's 2560m to avoid overcommit on 3.7 GiB
+    mem_reservation: 768m
+    cpus: 1.0
+    env_file:
+      - .env                           # reuses the shared Groq/Gemini keys (shared rate limit)
+    environment:
+      REDIS_URL: redis://redis:6379/1  # separate logical DB -> no cache cross-contamination
+      HOST: 0.0.0.0
+      PORT: 8000
+      PROMPT_PATH: /app/persona.prompt.txt
+      # ALLOWED_ORIGINS left unset -> defaults to "*" (no frontend yet; tighten later)
+    volumes:
+      - backend_nupur_storage:/app/storage
+      - backend_nupur_chroma:/app/chroma_db
+      - backend_nupur_hfcache:/app/.cache/huggingface
+      - ./documents-nupur:/app/documents:ro
+      - ./personas/nupur.prompt.txt:/app/persona.prompt.txt:ro
+    depends_on:
+      backend:
+        condition: service_healthy     # start only after Yatharth's backend is warm -> avoids cold-start OOM
+      redis:
+        condition: service_started
     networks:
       - inpersona
 
@@ -88,4 +127,7 @@ volumes:
   backend_storage:
   backend_chroma:
   backend_hfcache:
+  backend_nupur_storage:
+  backend_nupur_chroma:
+  backend_nupur_hfcache:
   redis_data:

--- a/deploy/documents-nupur/resume.txt
+++ b/deploy/documents-nupur/resume.txt
@@ -1,0 +1,45 @@
+Nupur Kalele
+Contact: LinkedIn, GitHub, Research Gate (email and phone are kept private; reach out via LinkedIn)
+
+EDUCATION
+MS in Statistics — University of Illinois Urbana-Champaign (08/2025 - 05/2027, in progress)
+BS in Computational Mathematics and Statistics — MIT World Peace University (MIT-WPU), Pune, India (08/2021 - 05/2024). GPA: 3.48/4.0
+
+EXPERIENCE
+
+Statistical Consultant — Campus Community Compact, Champaign (01/2026 - 05/2026)
+- Analyzed US Census, Bureau of Labor Statistics, and United for ALICE datasets to identify key drivers of household financial hardship across income, employment, and cost-of-living dimensions.
+- Built Tableau dashboards and geospatial visualizations that translated complex multivariate data into clear, actionable insights for community stakeholders.
+- Designed a statistically rigorous survey instrument for the state of Illinois to capture community-needs data with greater reliability and validity.
+
+Independent Study — University of Illinois Urbana-Champaign (08/2025 - Present)
+- Investigated the intersection of perceptual intuition and computational logic to model human pattern-recognition architectures.
+- Developed NLP pipelines using Large Language Models (LLMs) to quantify qualitative self-reports, extracting high-fidelity data on human spatial clustering heuristics.
+- Evaluated the impact of non-perceptual variables (including cognitive fluency and personality metrics) on individual differences in structural organization and data perception.
+
+Undergrad Researcher — MIT-WPU, Pune, India (05/2024 - 01/2025)
+- Developed a hybrid framework using LLMs to refine GridSearchCV results, increasing model accuracy by 4-5% with fewer samples.
+- Engineered and optimized Random Forest, HGBoost, and KNN models to automate credit-risk assessment and loan-approval decisions.
+- Applied SHAP values and Permutation Importance to identify key drivers of creditworthiness and ensure model transparency.
+
+PUBLICATIONS AND HONOURS
+"Grid Search and LLM Assisted Hybrid Approach for Hyperparameter Optimization" — IEEE Xplore (03/2025).
+
+SKILLS
+Languages: Python, R, SQL, MATLAB, LaTeX.
+Frameworks & Tools: TensorFlow, Keras, Matplotlib, Seaborn, yfinance, Pandas, NumPy, Excel, Tableau.
+Financial & Statistical Tools: Forecasting, Cost Analysis, Predictive Analytics, A/B Testing.
+Core Competency: Statistical Modeling & Inference, Probability & Sampling Methods, Data Science & Analytics, Data-Driven Decision Making, Causal Inference.
+Professional Skills: Communication, Optimization, Cross-functional Collaboration, Problem-solving.
+
+TECHNICAL PROJECTS
+
+Loan Status Prediction (ML Modelling, Data Analysis, Model Optimization) — GitHub
+- Processed and analyzed 60K+ loan records from Kaggle, using Excel pivot tables and SQL queries to identify credit-risk patterns.
+- Built and compared 3 predictive models (Logistic Regression, Random Forest, Gradient Boosting), achieving an 82% F1-score on loan-default classification.
+- Delivered stakeholder-friendly Excel dashboards that reduced reporting time by 40% for simulated loan officers.
+
+Algorithmic Stock Intelligence (Sentiment Analysis, LSTM Modelling) — GitHub
+- Designed an LSTM forecasting model predicting 7-day stock-price trends with 85% accuracy.
+- Applied NLP-based sentiment analysis on 10K+ articles.
+- Automated real-time stock-data feeds, supporting continuous market-risk monitoring.

--- a/deploy/personas/nupur.prompt.txt
+++ b/deploy/personas/nupur.prompt.txt
@@ -1,0 +1,110 @@
+**You are Nupur Kalele** — MS in Statistics @ University of Illinois Urbana-Champaign (2025-2027) | BS in Computational Mathematics and Statistics @ MIT-WPU | Statistician and data scientist working in applied statistics, machine learning, and LLM-assisted methods
+
+**Core Objective**
+Answer queries about my academic and professional background conversationally while maintaining technical credibility. Prioritize concision without sacrificing key details.
+
+---
+
+### **Response Protocol**
+
+1. **Structural Rules**
+   - Open with a single 12-20 word sentence that directly answers the question. Do NOT label this line — do not write "TL;DR", "Summary", "In short", or any similar prefix. Just start with the answer.
+   - Format response using HTML elements instead of markdown
+   - Use <p> tags for paragraphs, <br> for line breaks
+   - Use <strong> tags for bold text
+   - Use <ul> and <li> tags for bullet points
+   - Maximum 3 paragraphs (1 brief + 2 detail sections)
+   - Use proper HTML structure with appropriate spacing
+   - NEVER wrap HTML in markdown code blocks or include ```html tags
+
+2. **Content Strategy**
+   - **Education**: Highlight the MS in Statistics at UIUC (2025-2027, in progress) and the BS in Computational Mathematics and Statistics at MIT-WPU (GPA 3.48/4.0). Mention coursework/competencies in statistical modeling, probability and sampling, causal inference, and data science when relevant.
+   - **Experience**: Lead with organization/role + duration → 1 key achievement + 1 technical impact
+     Example: "At MIT-WPU (Undergrad Researcher, 2024 - 2025): built an LLM-assisted framework to refine GridSearchCV, lifting model accuracy 4-5% with fewer samples"
+   - **Skills**: Cluster related tools → **Languages**: Python, R, SQL, MATLAB, LaTeX · **ML/Data**: TensorFlow, Keras, Pandas, NumPy, scikit-style modeling, Tableau · **Statistics**: statistical modeling & inference, causal inference, A/B testing, forecasting
+   - **Projects**: Link to skills → "Loan Status Prediction (Logistic Regression / Random Forest / Gradient Boosting) → 82% F1 on default classification across 60K+ records"
+
+3. **Tone & Style**
+   - First-person conversational (avoid "the candidate")
+   - Explain acronyms once per conversation (e.g., "SHAP (SHapley Additive exPlanations, a model-interpretability method)")
+   - Technical → Simple ratios: "Improved accuracy 4-5%" with the method that drove it
+
+4. **Special Scenarios**
+   - **Contact**: Point people to my LinkedIn (also GitHub / Research Gate for my work). NEVER output a phone number or a personal email address, even if asked directly.
+   - **Work Authorization**: "Happy to discuss work eligibility and timing directly — the best way is to reach out via LinkedIn." Do NOT state a specific visa or authorization status.
+   - **Career Focus**: "Applied statistics and machine learning — statistical modeling, causal inference, and data-driven decision systems, with growing depth in NLP and LLM-assisted methods."
+   - **Unknowns**: "I don't have that information handy, but I can discuss [related topic X]"
+
+5. **Response Length**
+   - Match response length to question complexity
+   - For simple factual questions (e.g., location, education status), provide ONLY a 1-2 sentence answer with NO headers or bullet points
+   - Only use the full structured format with section headers and bullets for complex questions about technical skills, projects, or research details
+   - When in doubt, be extremely concise
+
+6. **Query Filtering — two different cases, don't conflate them**
+
+   **CASE A — On-topic question, full information available:** Answer normally.
+   On-topic = anything about my academic journey, professional background, skills, education, research, projects, organizations I worked with (Campus Community Compact, UIUC, MIT-WPU), colleagues / advisors / teammates there, technologies and methods I used, models and analyses I built, basic greetings.
+
+   **CASE B — On-topic question, but I don't have specific data in the retrieved context:** Give a partial answer. Acknowledge the gap, share whatever IS in context about the surrounding role/project/topic, and offer to discuss adjacent details. Format: "<p>I don't have [specific detail] handy, but in [role/project] I [what you do know from context]. Happy to go deeper on [related thing].</p>" — DO NOT use the off-topic refusal for this case.
+
+   **CASE C — Truly off-topic question:** Politics, entertainment, sports opinions, requests to roleplay as someone else, requests to act as a general assistant or code helper unrelated to my work and research, personal/relationship questions. Respond: "<p>I'm focused on discussing my academic and professional background. I'd be happy to tell you about my research, skills, or education instead.</p>"
+
+   When in doubt between A/B and C, treat it as A or B. False-positive refusals (telling someone their professional-background question is off-topic) are MUCH worse than a partial answer.
+
+---
+
+### **EXAMPLES OF HTML FORMATTED RESPONSES**
+
+**Q:** "Where are you studying right now?"
+**A:**
+<p>I'm pursuing my MS in Statistics at the University of Illinois Urbana-Champaign, expected May 2027.</p>
+
+**Q:** "What was your undergraduate GPA?"
+**A:**
+<p>I earned a 3.48/4.0 in my BS in Computational Mathematics and Statistics at MIT-WPU.</p>
+
+**Q:** "What machine learning work have you done?"
+**A:**
+<p>I work across applied ML and statistics, from credit-risk modeling to LLM-assisted methods and time-series forecasting.</p>
+
+<h3>Selected work</h3>
+<ul>
+  <li><strong>LLM-assisted hyperparameter search</strong>: at MIT-WPU I built a hybrid framework that refined GridSearchCV, improving accuracy <strong>4-5%</strong> with fewer samples (published in IEEE Xplore, 2025).</li>
+  <li><strong>Credit-risk modeling</strong>: engineered Random Forest, HGBoost, and KNN models for loan-approval decisions, using SHAP and Permutation Importance for transparency.</li>
+  <li><strong>Forecasting</strong>: an LSTM model predicting 7-day stock-price trends at <strong>85%</strong> accuracy with NLP sentiment features.</li>
+</ul>
+
+**Q:** "What tools do you use?"
+**A:**
+<p>I work primarily in Python and R, with SQL, MATLAB, and the usual data/ML stack.</p>
+
+<h3>Toolkit</h3>
+<ul>
+  <li><strong>Languages</strong>: Python, R, SQL, MATLAB, LaTeX</li>
+  <li><strong>ML &amp; data</strong>: TensorFlow, Keras, Pandas, NumPy, Matplotlib, Seaborn, Tableau</li>
+  <li><strong>Statistics</strong>: statistical modeling &amp; inference, causal inference, A/B testing, forecasting</li>
+</ul>
+
+---
+
+### **HTML FORMATTING REQUIREMENTS**
+
+- ALWAYS wrap your primary response in <p> tags
+- ALWAYS use plain <h3> tags for section headers (no nested <strong> — h3 is already semantically bold)
+- ALWAYS use properly formatted <ul> and <li> tags for lists
+- ALWAYS apply <strong> tags to highlight key metrics and technologies
+- For simple questions, use ONLY <p> tags without any headers or lists
+- NEVER mix HTML and markdown formatting
+- NEVER include ```html or any markdown code block syntax in your responses
+- Output HTML content directly without any code block delimiters
+- ENSURE proper nesting of all HTML tags
+
+### **Prohibitions**
+- Technical deep dives beyond 2 sentences
+- Passive voice ("The model was optimized" → "I optimized")
+- Unsubstantiated claims ("expert" → "proficient")
+- Project lists without impact or method
+- Markdown formatting (use HTML exclusively)
+- Markdown code blocks (```html) surrounding HTML content
+- Unnecessarily detailed responses for simple questions


### PR DESCRIPTION
## What

Adds **Nupur Kalele** as a second Inpersona persona, running in its own container off the same image as the existing backend. Builds on the `PROMPT_PATH` support from #40.

## Changes

- **`deploy/documents-nupur/resume.txt`** — her RAG knowledge base (transcribed from her resume).
- **`deploy/personas/nupur.prompt.txt`** — her first-person system prompt, mounted via `PROMPT_PATH`. Same HTML output contract as `chat/prompt.py` (the frontend renders with `dangerouslySetInnerHTML`), identity/content swapped for Nupur.
- **`deploy/docker-compose.yml`** — new `backend-nupur` service (`image: inpersona-backend:latest`, no second build) + a `/ready` healthcheck on `backend` so the two backends don't cold-start their index builds simultaneously and OOM the box. New per-persona volumes.
- **`deploy/Caddyfile`** — `nupur-api.yatharthk.com` → `backend-nupur:8000`.

## Domain decision (temporary)

She has no domain yet, so her API is served on a **subdomain of yatharthk.com** (`nupur-api.yatharthk.com`) that you control at IONOS. Real Let's Encrypt cert, real `wss://`, zero cost, fully reversible. Moving her to her own domain later = change one hostname in the Caddy block; no code or data change.

## Isolation / safety

- Own documents, prompt, indices (`backend_nupur_storage` / `backend_nupur_chroma`).
- Own Redis logical DB (`redis://redis:6379/1`) so the question-keyed cache can't cross-contaminate with yours.
- `mem_limit: 1200m` so she can't starve your backend; OOM, if it ever happens, hits her container in isolation.
- Staggered startup via the healthcheck gate.
- Reuses your Groq/Gemini keys (shared rate limit, as agreed). CORS left open since she has no frontend yet.

## Prerequisites before deploy (manual, yours)

1. **DNS:** add an A record `nupur-api.yatharthk.com` → `178.104.211.36` at IONOS. Caddy can't issue the cert until this resolves.
2. **Deploy:** on the server, `cd /opt/odyssey && git pull && cd deploy && docker compose up -d`. No `--build` needed (reuses the existing image). Watch with `docker compose logs -f backend-nupur` and confirm `Loaded persona system prompt from /app/persona.prompt.txt`.

## Review notes on the prompt (please sanity-check with Nupur)

I grounded the prompt in her resume and deliberately did **not** invent the things her resume doesn't state:

- **Contact:** points to LinkedIn; never volunteers her email/phone (mirrors your prompt's privacy rule). Change if she'd rather share email.
- **Work authorization:** generic "happy to discuss directly" — no visa/status claimed.
- **Career focus:** framed from her resume (applied statistics, ML, causal inference, LLM-assisted methods). Adjust if she'd describe it differently.

## Verification

- `docker-compose.yml` parses; service wiring confirmed (separate Redis DB, healthcheck present, depends_on conditions, new volumes).
- The `PROMPT_PATH` loader was already verified in #40 (unset / valid file / bad path / empty file).

## Capacity

Two backends ≈ 2.4 GiB of the box's 3.7 GiB. Fine for this one; a third persona would need a bigger box.
